### PR TITLE
feat: 그룹 상세 화면 UI 구현

### DIFF
--- a/client/presentation/src/main/java/com/andone/memorip/navigation/MemoripNav.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/navigation/MemoripNav.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDe
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay
+import com.andone.memorip.presentation.groupdetail.groupDetail
 import com.andone.memorip.presentation.home.home
 
 @Composable
@@ -39,6 +40,13 @@ fun MemoripNav(
         entryProvider = entryProvider {
             home(
                 onCreateGroupClick = {},
+                onGroupClick = { groupId ->
+                    navigator.navigateToRoute(GroupDetail(groupId))
+                },
+                modifier = modifier
+            )
+            groupDetail(
+                onBackClick = { navigator.popBackStack() },
                 modifier = modifier
             )
             entry<User> { Text(text = "user") }

--- a/client/presentation/src/main/java/com/andone/memorip/navigation/MemoripNav.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/navigation/MemoripNav.kt
@@ -11,6 +11,7 @@ import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay
 import com.andone.memorip.presentation.groupdetail.groupDetail
+import com.andone.memorip.presentation.groupdetail.navigateToGroupDetail
 import com.andone.memorip.presentation.home.home
 import com.andone.memorip.presentation.selectgroup.selectGroup
 import com.andone.memorip.presentation.selectcategory.selectCategory
@@ -43,12 +44,12 @@ fun MemoripNav(
             home(
                 onCreateGroupClick = {},
                 onGroupClick = { groupId ->
-                    navigator.navigateToRoute(GroupDetail(groupId))
+                    navigator.navigateToGroupDetail(groupId)
                 },
                 modifier = modifier
             )
             groupDetail(
-                onBackClick = { navigator.popBackStack() },
+                onNavigateBack = { navigator.popBackStack() },
                 modifier = modifier
             )
             entry<User> { Text(text = "user") }

--- a/client/presentation/src/main/java/com/andone/memorip/navigation/MemoripNavigator.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/navigation/MemoripNavigator.kt
@@ -6,8 +6,8 @@ import androidx.compose.runtime.remember
 import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.rememberNavBackStack
+import com.andone.memorip.presentation.groupdetail.navigateToGroupDetail
 import kotlinx.collections.immutable.toImmutableList
-import okhttp3.Route
 
 @Stable
 class MemoripNavigator(
@@ -37,10 +37,7 @@ class MemoripNavigator(
 
     fun navigateToSelectGroup() = addStack(SelectGroup)
 
-    fun navigateToRoute(route: NavKey) {
-        if (currentTab?.route == route) return
-        backStack.add(route)
-    }
+    fun navigateToGroupDetail(groupId: String) = backStack.navigateToGroupDetail(groupId)
 
     fun popBackStack() = backStack.removeLastOrNull()
 

--- a/client/presentation/src/main/java/com/andone/memorip/navigation/MemoripNavigator.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/navigation/MemoripNavigator.kt
@@ -32,6 +32,11 @@ class MemoripNavigator(
         backStack.add(tab.route)
     }
 
+    fun navigateToRoute(route: NavKey) {
+        if (currentTab?.route == route) return
+        backStack.add(route)
+    }
+
     fun popBackStack() = backStack.removeLastOrNull()
 }
 

--- a/client/presentation/src/main/java/com/andone/memorip/navigation/Route.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/navigation/Route.kt
@@ -8,3 +8,6 @@ data object Home : NavKey
 
 @Serializable
 data object User : NavKey
+
+@Serializable
+data class GroupDetail(val groupId: String) : NavKey

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/component/MemoripStaggeredGrid.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/component/MemoripStaggeredGrid.kt
@@ -78,8 +78,8 @@ private fun StaggeredImageItem(
             model = imageUrl,
             contentDescription = contentDescription,
             modifier = Modifier.fillMaxWidth(),
-            placeholder = ColorPainter(MemoripTheme.colors.gray),
-            error = ColorPainter(MemoripTheme.colors.gray),
+            placeholder = ColorPainter(MemoripTheme.colors.offWhite),
+            error = ColorPainter(MemoripTheme.colors.offWhite),
             contentScale = ContentScale.FillWidth
         )
     }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/component/MemoripStaggeredGrid.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/component/MemoripStaggeredGrid.kt
@@ -4,10 +4,9 @@ import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
 import androidx.compose.foundation.lazy.staggeredgrid.items
@@ -25,7 +24,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.andone.memorip.presentation.R
-import com.andone.memorip.presentation.model.ImageItem
+import com.andone.memorip.presentation.groupdetail.model.PlaceImageItem
 import com.andone.memorip.presentation.theme.MemoripSpace
 import com.andone.memorip.presentation.theme.MemoripTheme
 
@@ -35,17 +34,24 @@ private object StaggeredGridDimens {
 }
 
 @Composable
-fun MemoripStaggeredGrid(modifier: Modifier = Modifier) {
-    val images = remember { generateRandomImageUrls(50) }
-
+fun MemoripStaggeredGrid(
+    images: List<PlaceImageItem>,
+    modifier: Modifier = Modifier
+) {
     LazyVerticalStaggeredGrid(
         columns = StaggeredGridCells.Adaptive(StaggeredGridDimens.STAGGERED_GRID_MIN_CELL_WIDTH),
         verticalItemSpacing = MemoripSpace.SpaceXXSmall,
         horizontalArrangement = Arrangement.spacedBy(MemoripSpace.SpaceXXSmall),
         modifier = modifier.fillMaxSize(),
         content = {
-            items(images) { image ->
-                StaggeredImageItem(imageUrl = image.url)
+            items(
+                items = images,
+                key = { it.id }
+            ) { image ->
+                StaggeredImageItem(
+                    imageUrl = image.url,
+                    aspectRatio = image.aspectRatio
+                )
             }
         }
     )
@@ -54,21 +60,16 @@ fun MemoripStaggeredGrid(modifier: Modifier = Modifier) {
 @Composable
 private fun StaggeredImageItem(
     imageUrl: String,
+    aspectRatio: Float,
     modifier: Modifier = Modifier,
-    fixedHeight: Dp? = null,
     cornerRadius: Dp = StaggeredGridDimens.STAGGERED_GRID_IMAGE_CORNER_RADIUS,
-    contentDescription: String = stringResource(R.string.staggered_grid_image_content_description)
+    contentDescription: String? = null
 ) {
+    val description = contentDescription ?: stringResource(R.string.staggered_grid_image_content_description)
     Box(
         modifier = modifier
             .fillMaxWidth()
-            .then(
-                if (fixedHeight != null) {
-                    Modifier.height(fixedHeight)
-                } else {
-                    Modifier.wrapContentHeight()
-                }
-            )
+            .aspectRatio(aspectRatio)
             .clip(RoundedCornerShape(cornerRadius))
             .background(MemoripTheme.colors.gray),
         contentAlignment = Alignment.Center
@@ -89,38 +90,36 @@ private fun StaggeredImageItem(
  * picsum 사이트에서 200x랜덤height로 crop해서 가져옴.
  * todo: 백엔드에서 받아온 이미지로 변경
  */
-fun generateRandomImageUrls(count: Int): List<ImageItem> {
+fun generateRandomImageUrls(count: Int): List<PlaceImageItem> {
     return (1..count).map { id ->
-        val height = (50..400).random()
+        val randomHeight = (50..400).random()
+        val fixedWidth = 200
 
-        ImageItem(
+        PlaceImageItem(
             id = id,
-            url = "https://picsum.photos/id/$id/200/$height"
+            url = "https://picsum.photos/id/$id/$fixedWidth/$randomHeight",
+            width = fixedWidth,
+            height = randomHeight
         )
     }
 }
 
 @Preview(showBackground = true)
-@Preview(showBackground = true, uiMode = UI_MODE_NIGHT_YES)
 @Composable
 private fun MemoripStaggeredGridPreview() {
     MemoripTheme {
-        // 30개의 랜덤한 높이 생성 (50~400)
-        val dummyHeights = remember {
-            List(30) { (50..400).random() }
-        }
-        LazyVerticalStaggeredGrid(
-            columns = StaggeredGridCells.Adaptive(StaggeredGridDimens.STAGGERED_GRID_MIN_CELL_WIDTH),
-            verticalItemSpacing = MemoripSpace.SpaceXXSmall,
-            horizontalArrangement = Arrangement.spacedBy(MemoripSpace.SpaceXXSmall),
-            modifier = Modifier.fillMaxSize(),
-        ) {
-            items(30) { index ->
-                StaggeredImageItem(
-                    imageUrl = "https://picsum.photos/id/${index + 1}/200/${dummyHeights[index]}",
-                    fixedHeight = dummyHeights[index].dp
-                )
-            }
-        }
+        val dummyImages = remember { generateRandomImageUrls(count = 30) }
+        MemoripStaggeredGrid(images = dummyImages)
+    }
+}
+
+@Preview
+@Composable
+private fun StaggeredImageItemPreview() {
+    MemoripTheme {
+        StaggeredImageItem(
+            imageUrl = "https://picsum.photos/id/1/200/300",
+            aspectRatio = 1f
+        )
     }
 }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/component/MemoripStaggeredGrid.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/component/MemoripStaggeredGrid.kt
@@ -1,6 +1,5 @@
 package com.andone.memorip.presentation.component
 
-import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -12,7 +11,6 @@ import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
 import androidx.compose.foundation.lazy.staggeredgrid.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -27,6 +25,7 @@ import com.andone.memorip.presentation.R
 import com.andone.memorip.presentation.groupdetail.model.PlaceImageItem
 import com.andone.memorip.presentation.theme.MemoripSpace
 import com.andone.memorip.presentation.theme.MemoripTheme
+import com.andone.memorip.presentation.util.DummyData
 
 private object StaggeredGridDimens {
     val STAGGERED_GRID_MIN_CELL_WIDTH = 160.dp
@@ -85,31 +84,11 @@ private fun StaggeredImageItem(
     }
 }
 
-/**
- * 랜덤 높이 이미지 count 개 생성.
- * picsum 사이트에서 200x랜덤height로 crop해서 가져옴.
- * todo: 백엔드에서 받아온 이미지로 변경
- */
-fun generateRandomImageUrls(count: Int): List<PlaceImageItem> {
-    return (1..count).map { id ->
-        val randomHeight = (50..400).random()
-        val fixedWidth = 200
-
-        PlaceImageItem(
-            id = id,
-            url = "https://picsum.photos/id/$id/$fixedWidth/$randomHeight",
-            width = fixedWidth,
-            height = randomHeight
-        )
-    }
-}
-
 @Preview(showBackground = true)
 @Composable
 private fun MemoripStaggeredGridPreview() {
     MemoripTheme {
-        val dummyImages = remember { generateRandomImageUrls(count = 30) }
-        MemoripStaggeredGrid(images = dummyImages)
+        MemoripStaggeredGrid(images = DummyData.dummyImages)
     }
 }
 

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/GroupDetailNavGraph.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/GroupDetailNavGraph.kt
@@ -2,16 +2,21 @@ package com.andone.memorip.presentation.groupdetail
 
 import androidx.compose.ui.Modifier
 import androidx.navigation3.runtime.EntryProviderScope
+import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavKey
 import com.andone.memorip.navigation.GroupDetail
 
+fun NavBackStack<NavKey>.navigateToGroupDetail(groupId: String) {
+    add(GroupDetail(groupId))
+}
+
 fun EntryProviderScope<NavKey>.groupDetail(
-    onBackClick: () -> Unit,
+    onNavigateBack: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    entry<GroupDetail> { backStackEntry ->
+    entry<GroupDetail> { route ->
         GroupDetailScreen(
-            onBackClick = onBackClick,
+            onBackClick = onNavigateBack,
             modifier = modifier
         )
     }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/GroupDetailNavGraph.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/GroupDetailNavGraph.kt
@@ -1,0 +1,18 @@
+package com.andone.memorip.presentation.groupdetail
+
+import androidx.compose.ui.Modifier
+import androidx.navigation3.runtime.EntryProviderScope
+import androidx.navigation3.runtime.NavKey
+import com.andone.memorip.navigation.GroupDetail
+
+fun EntryProviderScope<NavKey>.groupDetail(
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    entry<GroupDetail> { backStackEntry ->
+        GroupDetailScreen(
+            onBackClick = onBackClick,
+            modifier = modifier
+        )
+    }
+}

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/GroupDetailScreen.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/GroupDetailScreen.kt
@@ -26,6 +26,37 @@ import kotlinx.coroutines.launch
 
 @Composable
 fun GroupDetailScreen(
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    // 임시 더미 데이터 생성
+    // todo: 실제 groupId를 가져와서 그룹 정보를 가져와야 함
+    val groupName = "Group1"
+    val dummyImages = remember {
+        List(30) { index ->
+            val randomHeight = (150..400).random()
+            val fixedWidth = 200
+            PlaceImageItem(
+                id = index,
+                url = "https://picsum.photos/id/${index + 1}/$fixedWidth/$randomHeight",
+                width = fixedWidth,
+                height = randomHeight
+            )
+        }
+    }
+
+    GroupDetailScreenContent(
+        groupName = groupName,
+        images = dummyImages,
+        onBackClick = onBackClick,
+        onSearchClick = { /* TODO: 검색 기능 구현 */ },
+        onMenuClick = { /* TODO: 메뉴 기능 구현 */ },
+        modifier = modifier
+    )
+}
+
+@Composable
+fun GroupDetailScreenContent(
     groupName: String,
     images: List<PlaceImageItem>,
     onBackClick: () -> Unit,
@@ -95,7 +126,7 @@ fun GroupDetailScreen(
 
 @Preview(name = "Gallery Tab Selected")
 @Composable
-private fun GroupDetailScreenGalleryPreview() {
+private fun GroupDetailScreenContentGalleryPreview() {
     MemoripTheme {
         val dummyImages = remember {
             List(30) { index ->
@@ -110,7 +141,7 @@ private fun GroupDetailScreenGalleryPreview() {
             }
         }
 
-        GroupDetailScreen(
+        GroupDetailScreenContent(
             groupName = "Group1",
             images = dummyImages,
             onBackClick = {},
@@ -123,7 +154,7 @@ private fun GroupDetailScreenGalleryPreview() {
 
 @Preview(name = "Map Tab Selected")
 @Composable
-private fun GroupDetailScreenMapPreview() {
+private fun GroupDetailScreenContentMapPreview() {
     MemoripTheme {
         val dummyImages = remember {
             List(30) { index ->
@@ -138,7 +169,7 @@ private fun GroupDetailScreenMapPreview() {
             }
         }
 
-        GroupDetailScreen(
+        GroupDetailScreenContent(
             groupName = "Group1",
             images = dummyImages,
             onBackClick = {},

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/GroupDetailScreen.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/GroupDetailScreen.kt
@@ -22,6 +22,7 @@ import com.andone.memorip.presentation.groupdetail.component.GroupDetailAppBar
 import com.andone.memorip.presentation.groupdetail.component.MapTab
 import com.andone.memorip.presentation.groupdetail.model.PlaceImageItem
 import com.andone.memorip.presentation.theme.MemoripTheme
+import com.andone.memorip.presentation.util.DummyData
 import kotlinx.coroutines.launch
 
 @Composable
@@ -76,6 +77,7 @@ fun GroupDetailScreenContent(
     val coroutineScope = rememberCoroutineScope()
 
     Scaffold(
+        modifier = modifier,
         topBar = {
             GroupDetailAppBar(
                 title = groupName,
@@ -84,7 +86,6 @@ fun GroupDetailScreenContent(
                 onSearchClick = onSearchClick
             )
         },
-        modifier = modifier
     ) { innerPadding ->
         Column(
             modifier = Modifier
@@ -128,22 +129,9 @@ fun GroupDetailScreenContent(
 @Composable
 private fun GroupDetailScreenContentGalleryPreview() {
     MemoripTheme {
-        val dummyImages = remember {
-            List(30) { index ->
-                val randomHeight = (150..400).random()
-                val fixedWidth = 200
-                PlaceImageItem(
-                    id = index,
-                    url = "https://picsum.photos/id/${index + 1}/$fixedWidth/$randomHeight",
-                    width = fixedWidth,
-                    height = randomHeight
-                )
-            }
-        }
-
         GroupDetailScreenContent(
             groupName = "Group1",
-            images = dummyImages,
+            images = DummyData.dummyImages,
             onBackClick = {},
             onSearchClick = {},
             onMenuClick = {},
@@ -156,22 +144,9 @@ private fun GroupDetailScreenContentGalleryPreview() {
 @Composable
 private fun GroupDetailScreenContentMapPreview() {
     MemoripTheme {
-        val dummyImages = remember {
-            List(30) { index ->
-                val randomHeight = (150..400).random()
-                val fixedWidth = 200
-                PlaceImageItem(
-                    id = index,
-                    url = "https://picsum.photos/id/${index + 1}/$fixedWidth/$randomHeight",
-                    width = fixedWidth,
-                    height = randomHeight
-                )
-            }
-        }
-
         GroupDetailScreenContent(
             groupName = "Group1",
-            images = dummyImages,
+            images = DummyData.dummyImages,
             onBackClick = {},
             onSearchClick = {},
             onMenuClick = {},

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/GroupDetailScreen.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/GroupDetailScreen.kt
@@ -1,0 +1,150 @@
+package com.andone.memorip.presentation.groupdetail
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material3.PrimaryTabRow
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Tab
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import com.andone.memorip.presentation.R
+import com.andone.memorip.presentation.groupdetail.component.GalleryTab
+import com.andone.memorip.presentation.groupdetail.component.GroupDetailAppBar
+import com.andone.memorip.presentation.groupdetail.component.MapTab
+import com.andone.memorip.presentation.groupdetail.model.PlaceImageItem
+import com.andone.memorip.presentation.theme.MemoripTheme
+import kotlinx.coroutines.launch
+
+@Composable
+fun GroupDetailScreen(
+    groupName: String,
+    images: List<PlaceImageItem>,
+    onBackClick: () -> Unit,
+    onSearchClick: () -> Unit,
+    onMenuClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    initialPage: Int = 0
+) {
+    val tabs = listOf(
+        stringResource(R.string.groupdetail_tab_gallery),
+        stringResource(R.string.groupdetail_tab_map)
+    )
+    val pagerState = rememberPagerState(
+        initialPage = initialPage,
+        pageCount = { tabs.size }
+    )
+    val coroutineScope = rememberCoroutineScope()
+
+    Scaffold(
+        topBar = {
+            GroupDetailAppBar(
+                title = groupName,
+                onBackClick = onBackClick,
+                onMenuClick = onMenuClick,
+                onSearchClick = onSearchClick
+            )
+        },
+        modifier = modifier
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+        ) {
+            PrimaryTabRow(
+                selectedTabIndex = pagerState.currentPage,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                tabs.forEachIndexed { index, title ->
+                    Tab(
+                        selected = pagerState.currentPage == index,
+                        onClick = {
+                            coroutineScope.launch {
+                                pagerState.animateScrollToPage(index)
+                            }
+                        },
+                        text = { Text(text = title) }
+                    )
+                }
+            }
+
+            HorizontalPager(
+                state = pagerState,
+                modifier = Modifier.fillMaxSize()
+            ) { page ->
+                when (page) {
+                    0 -> GalleryTab(
+                        images = images,
+                        modifier = Modifier.fillMaxSize()
+                    )
+                    1 -> MapTab(modifier = Modifier.fillMaxSize())
+                }
+            }
+        }
+    }
+}
+
+@Preview(name = "Gallery Tab Selected")
+@Composable
+private fun GroupDetailScreenGalleryPreview() {
+    MemoripTheme {
+        val dummyImages = remember {
+            List(30) { index ->
+                val randomHeight = (150..400).random()
+                val fixedWidth = 200
+                PlaceImageItem(
+                    id = index,
+                    url = "https://picsum.photos/id/${index + 1}/$fixedWidth/$randomHeight",
+                    width = fixedWidth,
+                    height = randomHeight
+                )
+            }
+        }
+
+        GroupDetailScreen(
+            groupName = "Group1",
+            images = dummyImages,
+            onBackClick = {},
+            onSearchClick = {},
+            onMenuClick = {},
+            initialPage = 0
+        )
+    }
+}
+
+@Preview(name = "Map Tab Selected")
+@Composable
+private fun GroupDetailScreenMapPreview() {
+    MemoripTheme {
+        val dummyImages = remember {
+            List(30) { index ->
+                val randomHeight = (150..400).random()
+                val fixedWidth = 200
+                PlaceImageItem(
+                    id = index,
+                    url = "https://picsum.photos/id/${index + 1}/$fixedWidth/$randomHeight",
+                    width = fixedWidth,
+                    height = randomHeight
+                )
+            }
+        }
+
+        GroupDetailScreen(
+            groupName = "Group1",
+            images = dummyImages,
+            onBackClick = {},
+            onSearchClick = {},
+            onMenuClick = {},
+            initialPage = 1
+        )
+    }
+}

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/component/GalleryTab.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/component/GalleryTab.kt
@@ -1,0 +1,45 @@
+package com.andone.memorip.presentation.groupdetail.component
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.andone.memorip.presentation.component.MemoripStaggeredGrid
+import com.andone.memorip.presentation.groupdetail.model.PlaceImageItem
+import com.andone.memorip.presentation.theme.MemoripTheme
+
+@Composable
+fun GalleryTab(
+    images: List<PlaceImageItem>,
+    modifier: Modifier = Modifier
+) {
+    MemoripStaggeredGrid(
+        images = images,
+        modifier = modifier
+    )
+}
+
+@Preview
+@Composable
+private fun GalleryTabPreview() {
+    MemoripTheme {
+        val dummyImages = remember {
+            List(30) { index ->
+                val randomHeight = (150..400).random()
+                val fixedWidth = 200
+                PlaceImageItem(
+                    id = index,
+                    url = "https://picsum.photos/id/${index + 1}/$fixedWidth/$randomHeight",
+                    width = fixedWidth,
+                    height = randomHeight
+                )
+            }
+        }
+        GalleryTab(
+            images = dummyImages,
+            modifier = Modifier.fillMaxSize()
+        )
+    }
+}

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/component/GalleryTab.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/component/GalleryTab.kt
@@ -3,12 +3,12 @@ package com.andone.memorip.presentation.groupdetail.component
 import android.content.res.Configuration
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.andone.memorip.presentation.component.MemoripStaggeredGrid
 import com.andone.memorip.presentation.groupdetail.model.PlaceImageItem
 import com.andone.memorip.presentation.theme.MemoripTheme
+import com.andone.memorip.presentation.util.DummyData
 
 @Composable
 fun GalleryTab(
@@ -25,20 +25,8 @@ fun GalleryTab(
 @Composable
 private fun GalleryTabPreview() {
     MemoripTheme {
-        val dummyImages = remember {
-            List(30) { index ->
-                val randomHeight = (150..400).random()
-                val fixedWidth = 200
-                PlaceImageItem(
-                    id = index,
-                    url = "https://picsum.photos/id/${index + 1}/$fixedWidth/$randomHeight",
-                    width = fixedWidth,
-                    height = randomHeight
-                )
-            }
-        }
         GalleryTab(
-            images = dummyImages,
+            images = DummyData.dummyImages,
             modifier = Modifier.fillMaxSize()
         )
     }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/component/GroupDetailAppBar.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/component/GroupDetailAppBar.kt
@@ -1,0 +1,72 @@
+package com.andone.memorip.presentation.groupdetail.component
+
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import com.andone.memorip.presentation.R
+import com.andone.memorip.presentation.theme.MemoripTheme
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun GroupDetailAppBar(
+    title: String,
+    onBackClick: () -> Unit,
+    onMenuClick: () -> Unit,
+    onSearchClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    CenterAlignedTopAppBar(
+        title = { Text(text = title) },
+        navigationIcon = {
+            IconButton(onClick = onBackClick) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_arrow_back),
+                    contentDescription = stringResource(R.string.groupdetail_back_button_content_description)
+                )
+            }
+        },
+        actions = {
+            IconButton(onClick = onMenuClick) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_more_vert),
+                    contentDescription = stringResource(R.string.groupdetail_menu_button_content_description)
+                )
+            }
+            IconButton(onClick = onSearchClick) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_search),
+                    contentDescription = stringResource(R.string.groupdetail_search_button_content_description)
+                )
+            }
+        },
+        colors = TopAppBarDefaults.topAppBarColors(
+            containerColor = MaterialTheme.colorScheme.primaryContainer,
+            titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+            navigationIconContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+            actionIconContentColor = MaterialTheme.colorScheme.onPrimaryContainer
+        ),
+        modifier = modifier
+    )
+}
+
+@Preview
+@Composable
+private fun GroupDetailAppBarPreview() {
+    MemoripTheme {
+        GroupDetailAppBar(
+            title = "Group1",
+            onBackClick = {},
+            onSearchClick = {},
+            onMenuClick = {}
+        )
+    }
+}

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/component/MapTab.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/component/MapTab.kt
@@ -1,0 +1,20 @@
+package com.andone.memorip.presentation.groupdetail.component
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.andone.memorip.presentation.theme.MemoripTheme
+
+@Composable
+fun MapTab(modifier: Modifier = Modifier) {
+    Text("map tab")
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun MapTabPreview() {
+    MemoripTheme {
+        MapTab()
+    }
+}

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/model/PlaceImageItem.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/model/PlaceImageItem.kt
@@ -1,0 +1,14 @@
+package com.andone.memorip.presentation.groupdetail.model
+
+import androidx.compose.runtime.Immutable
+
+@Immutable
+data class PlaceImageItem(
+    val id: Int,
+    val url: String,
+    val width: Int,
+    val height: Int
+) {
+    val aspectRatio: Float
+        get() = width.toFloat() / height.toFloat()
+}

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/home/HomeNavGraph.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/home/HomeNavGraph.kt
@@ -7,11 +7,13 @@ import com.andone.memorip.navigation.Home
 
 fun EntryProviderScope<NavKey>.home(
     onCreateGroupClick: () -> Unit,
+    onGroupClick: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     entry<Home> {
         HomeScreen(
             onCreateGroupClick = onCreateGroupClick,
+            onGroupClick = onGroupClick,
             modifier = modifier
         )
     }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/home/HomeScreen.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/home/HomeScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import com.andone.memorip.presentation.R
 import com.andone.memorip.presentation.component.GroupView
 import com.andone.memorip.presentation.home.model.GroupUiModel
@@ -27,6 +26,7 @@ import com.andone.memorip.presentation.theme.MemoripTheme
 @Composable
 fun HomeScreen(
     onCreateGroupClick: () -> Unit,
+    onGroupClick: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     HomeScreenContents(

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/model/ImageItem.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/model/ImageItem.kt
@@ -1,7 +1,0 @@
-package com.andone.memorip.presentation.model
-
-// todo: 실제 Image 모델로 대체 에정
-data class ImageItem(
-    val id: Int,
-    val url: String
-)

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/util/DummyData.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/util/DummyData.kt
@@ -1,0 +1,16 @@
+package com.andone.memorip.presentation.util
+
+import com.andone.memorip.presentation.groupdetail.model.PlaceImageItem
+
+object DummyData {
+    val dummyImages = List(30) { index ->
+        val randomHeight = (150..400).random()
+        val fixedWidth = 200
+        PlaceImageItem(
+            id = index,
+            url = "https://picsum.photos/id/${index + 1}/$fixedWidth/$randomHeight",
+            width = fixedWidth,
+            height = randomHeight
+        )
+    }
+}

--- a/client/presentation/src/main/res/drawable/ic_arrow_back.xml
+++ b/client/presentation/src/main/res/drawable/ic_arrow_back.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:autoMirrored="true" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M20,11H7.83l5.59,-5.59L12,4l-8,8 8,8 1.41,-1.41L7.83,13H20v-2z"/>
+    
+</vector>

--- a/client/presentation/src/main/res/drawable/ic_more_vert.xml
+++ b/client/presentation/src/main/res/drawable/ic_more_vert.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M12,8c1.1,0 2,-0.9 2,-2s-0.9,-2 -2,-2 -2,0.9 -2,2 0.9,2 2,2zM12,10c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2zM12,16c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2z"/>
+    
+</vector>

--- a/client/presentation/src/main/res/drawable/ic_search.xml
+++ b/client/presentation/src/main/res/drawable/ic_search.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M15.5,14h-0.79l-0.28,-0.27C15.41,12.59 16,11.11 16,9.5 16,5.91 13.09,3 9.5,3S3,5.91 3,9.5 5.91,16 9.5,16c1.61,0 3.09,-0.59 4.23,-1.57l0.27,0.28v0.79l5,4.99L20.49,19l-4.99,-5zM9.5,14C7.01,14 5,11.99 5,9.5S7.01,5 9.5,5 14,7.01 14,9.5 11.99,14 9.5,14z"/>
+    
+</vector>

--- a/client/presentation/src/main/res/values/strings.xml
+++ b/client/presentation/src/main/res/values/strings.xml
@@ -19,4 +19,11 @@
     <string name="home_add_contentDescription">Add</string>
     <string name="home_overflow_count">+%1$d</string>
 
+    <!-- GroupDetailScreen-->
+    <string name="groupdetail_tab_gallery">갤러리</string>
+    <string name="groupdetail_tab_map">사진 지도</string>
+    <string name="groupdetail_map_placeholder">사진 지도 기능은 추후 구현 예정입니다</string>
+    <string name="groupdetail_back_button_content_description">뒤로 가기</string>
+    <string name="groupdetail_menu_button_content_description">메뉴</string>
+    <string name="groupdetail_search_button_content_description">검색</string>
 </resources>

--- a/client/presentation/src/main/res/values/strings.xml
+++ b/client/presentation/src/main/res/values/strings.xml
@@ -23,4 +23,12 @@
     <string name="main_bottom_bar_home">홈</string>
     <string name="main_bottom_bar_user">마이페이지</string>
 
+    <!-- GroupDetailScreen-->
+    <string name="groupdetail_tab_gallery">갤러리</string>
+    <string name="groupdetail_tab_map">사진 지도</string>
+    <string name="groupdetail_map_placeholder">사진 지도 기능은 추후 구현 예정입니다</string>
+    <string name="groupdetail_back_button_content_description">뒤로 가기</string>
+    <string name="groupdetail_menu_button_content_description">메뉴</string>
+    <string name="groupdetail_search_button_content_description">검색</string>
+
 </resources>


### PR DESCRIPTION
## 📝 변경 사항
그룹 상세 화면의 UI를 구현하고, 홈 화면에서 그룹 클릭 시 상세 화면으로 이동하는 네비게이션 기능을 추가했습니다.

## 🎯 작업 내용
- 그룹 상세 화면 UI 구현
  - 갤러리 탭과 지도 탭을 가진 탭 레이아웃 구현
  - TopAppBar에 뒤로가기, 검색, 메뉴 버튼 추가
  - Staggered Grid를 활용한 갤러리 뷰 구현
- 네비게이션 구조 개선
  - `GroupDetail` Route 추가
  - 홈 화면에서 그룹 클릭 시 상세 화면으로 이동하는 네비게이션 로직 구현
  - `MemoripNavigator`에 `navigateToRoute` 메서드 추가
- Staggered Grid 컴포넌트 개선
  - `PlaceImageItem` 모델로 이미지 데이터 구조화
  - 이미지 비율을 고려한 `aspectRatio` 적용
  - 이미지 placeholder 색상 개선
- 리소스 추가
  - 아이콘 추가 (뒤로가기, 메뉴, 검색)
  - 그룹 상세 화면 관련 문자열 리소스 추가

## 🔗 관련 이슈
Closes #15

## 📸 스크린샷 (선택사항)
<img width="50%" alt="image" src="https://github.com/user-attachments/assets/3406a87f-9f80-4b82-a7e8-b910a491473e" />


## 💬 리뷰어에게
- 갤러리 탭은 Staggered Grid로 구현했고, 지도 탭은 내용이 길어져서 다른 브랜치에서 작업중입니다.
- 현재는 더미 이미지 데이터를 사용하고 있습니다.