### PR TITLE
feat: 그룹 상세 화면 지도 탭 구현

### DIFF
--- a/client/gradle/libs.versions.toml
+++ b/client/gradle/libs.versions.toml
@@ -19,6 +19,9 @@ kotlinSerialization = "2.2.21"
 kotlinxSerializationCore = "1.9.0"
 material3AdaptiveNav3 = "1.3.0-alpha05"
 foundationLayout = "1.10.0"
+naverMap = "3.23.0"
+naverMapCompose = "1.9.0"
+naverMapLocation = "21.0.2"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -45,6 +48,9 @@ androidx-lifecycle-viewmodel-navigation3 = { module = "androidx.lifecycle:lifecy
 kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinxSerializationCore" }
 androidx-material3-adaptive-navigation3 = { group = "androidx.compose.material3.adaptive", name = "adaptive-navigation3", version.ref = "material3AdaptiveNav3" }
 androidx-foundation-layout = { group = "androidx.compose.foundation", name = "foundation-layout", version.ref = "foundationLayout" }
+naver-map-sdk = { group = "com.naver.maps", name = "map-sdk", version.ref = "naverMap" }
+naver-map-compose = { group = "io.github.fornewid", name = "naver-map-compose", version.ref = "naverMapCompose" }
+naver-map-location = { group = "io.github.fornewid", name = "naver-map-location", version.ref = "naverMapLocation" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/client/presentation/build.gradle.kts
+++ b/client/presentation/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
+
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
@@ -14,6 +16,9 @@ android {
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
+        
+        // Naver Map Key 주입
+        manifestPlaceholders["NAVER_MAP_NCP_KEY_ID"] = getLocalProperty("NAVER_MAP_NCP_KEY_ID")
     }
 
     buildTypes {
@@ -65,4 +70,17 @@ dependencies {
 
     // coil
     implementation(libs.coil.compose)
+
+    // Naver Map
+    implementation(libs.naver.map.sdk)
+    implementation(libs.naver.map.compose)
+    implementation(libs.naver.map.location)
+}
+
+fun getLocalProperty(propertyKey: String): String {
+    val properties = gradleLocalProperties(rootDir, providers)
+    return properties.getProperty(propertyKey) ?: run {
+        println("Warning: $propertyKey not found in local.properties")
+        ""
+    }
 }

--- a/client/presentation/src/main/AndroidManifest.xml
+++ b/client/presentation/src/main/AndroidManifest.xml
@@ -1,5 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+
+    <application>
+        <meta-data
+            android:name="com.naver.maps.map.NCP_KEY_ID"
+            android:value="${NAVER_MAP_NCP_KEY_ID}" />
+    </application>
 
 </manifest>

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/component/ErrorFullScreen.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/component/ErrorFullScreen.kt
@@ -43,7 +43,11 @@ fun ErrorFullScreen(
         Spacer(modifier = Modifier.height(MemoripSpace.SpaceLarge))
 
         Button(onClick = onRetry) {
-            Text(retryButtonText)
+            Text(
+                text = retryButtonText,
+                color = MemoripTheme.colors.white,
+                style = MemoripTheme.typography.label1
+            )
         }
     }
 }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/component/ErrorFullScreen.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/component/ErrorFullScreen.kt
@@ -1,0 +1,71 @@
+package com.andone.memorip.presentation.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import com.andone.memorip.presentation.R
+import com.andone.memorip.presentation.theme.MemoripPadding
+import com.andone.memorip.presentation.theme.MemoripSpace
+import com.andone.memorip.presentation.theme.MemoripTheme
+
+@Composable
+fun ErrorFullScreen(
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier,
+    message: String = stringResource(R.string.errorfullscreen_error_default_message),
+    retryButtonText: String = stringResource(R.string.errorfullscreen_retry_button),
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(MemoripPadding.PaddingLarge),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Text(
+            text = message,
+            color = MemoripTheme.colors.gray,
+            textAlign = TextAlign.Center
+        )
+
+        Spacer(modifier = Modifier.height(MemoripSpace.SpaceLarge))
+
+        Button(onClick = onRetry) {
+            Text(retryButtonText)
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun ErrorFullScreenPreview() {
+    MemoripTheme {
+        ErrorFullScreen(
+            onRetry = {}
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun ErrorFullScreenCustomPreview() {
+    MemoripTheme {
+        ErrorFullScreen(
+            onRetry = {},
+            message = "서버 연결에 실패했습니다\n잠시 후 다시 시도해주세요",
+            retryButtonText = "새로고침",
+        )
+    }
+}

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/component/ErrorFullScreen.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/component/ErrorFullScreen.kt
@@ -56,9 +56,7 @@ fun ErrorFullScreen(
 @Composable
 private fun ErrorFullScreenPreview() {
     MemoripTheme {
-        ErrorFullScreen(
-            onRetry = {}
-        )
+        ErrorFullScreen(onRetry = {})
     }
 }
 

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/component/ImageMarker.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/component/ImageMarker.kt
@@ -1,4 +1,4 @@
-package com.andone.memorip.presentation.groupdetail.component
+package com.andone.memorip.presentation.component
 
 import android.graphics.Bitmap
 import androidx.compose.foundation.Canvas
@@ -33,10 +33,9 @@ private object ImageMarkerDimen {
 @Composable
 fun ImageMarker(
     imageBitmap: Bitmap,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    borderColor: Color = MemoripTheme.colors.primaryContainer
 ) {
-    val borderColor = MemoripTheme.colors.primaryContainer
-
     Box(
         modifier = modifier.size(
             width = ImageMarkerDimen.ImageSize + MemoripPadding.PaddingXXSmall,

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/component/MemoripStaggeredGrid.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/component/MemoripStaggeredGrid.kt
@@ -26,6 +26,7 @@ import com.andone.memorip.presentation.R
 import com.andone.memorip.presentation.model.ImageItem
 import com.andone.memorip.presentation.theme.MemoripSpace
 import com.andone.memorip.presentation.theme.MemoripTheme
+import com.andone.memorip.presentation.util.DummyData
 
 private object StaggeredGridDimens {
     val STAGGERED_GRID_MIN_CELL_WIDTH = 160.dp
@@ -84,31 +85,11 @@ private fun StaggeredImageItem(
     }
 }
 
-/**
- * 랜덤 높이 이미지 count 개 생성.
- * picsum 사이트에서 200x랜덤height로 crop해서 가져옴.
- * todo: 백엔드에서 받아온 이미지로 변경
- */
-fun generateRandomImageUrls(count: Int): List<ImageItem> {
-    return (1..count).map { id ->
-        val randomHeight = (50..400).random()
-        val fixedWidth = 200
-
-        ImageItem(
-            id = id,
-            url = "https://picsum.photos/id/$id/$fixedWidth/$randomHeight",
-            width = fixedWidth,
-            height = randomHeight
-        )
-    }
-}
-
 @Preview(showBackground = true)
 @Composable
 private fun MemoripStaggeredGridPreview() {
     MemoripTheme {
-        val dummyImages = remember { generateRandomImageUrls(count = 30) }
-        MemoripStaggeredGrid(images = dummyImages)
+        MemoripStaggeredGrid(images = DummyData.imageItems)
     }
 }
 

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/component/MemoripStaggeredGrid.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/component/MemoripStaggeredGrid.kt
@@ -1,6 +1,5 @@
 package com.andone.memorip.presentation.component
 
-import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -24,7 +23,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.andone.memorip.presentation.R
-import com.andone.memorip.presentation.groupdetail.model.PlaceImageItem
+import com.andone.memorip.presentation.model.ImageItem
 import com.andone.memorip.presentation.theme.MemoripSpace
 import com.andone.memorip.presentation.theme.MemoripTheme
 
@@ -35,7 +34,7 @@ private object StaggeredGridDimens {
 
 @Composable
 fun MemoripStaggeredGrid(
-    images: List<PlaceImageItem>,
+    images: List<ImageItem>,
     modifier: Modifier = Modifier
 ) {
     LazyVerticalStaggeredGrid(
@@ -90,12 +89,12 @@ private fun StaggeredImageItem(
  * picsum 사이트에서 200x랜덤height로 crop해서 가져옴.
  * todo: 백엔드에서 받아온 이미지로 변경
  */
-fun generateRandomImageUrls(count: Int): List<PlaceImageItem> {
+fun generateRandomImageUrls(count: Int): List<ImageItem> {
     return (1..count).map { id ->
         val randomHeight = (50..400).random()
         val fixedWidth = 200
 
-        PlaceImageItem(
+        ImageItem(
             id = id,
             url = "https://picsum.photos/id/$id/$fixedWidth/$randomHeight",
             width = fixedWidth,

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/GroupDetailScreen.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/GroupDetailScreen.kt
@@ -1,53 +1,57 @@
 package com.andone.memorip.presentation.groupdetail
 
+import android.graphics.Bitmap
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.core.graphics.drawable.toBitmap
+import coil.ImageLoader
+import coil.request.ImageRequest
+import coil.request.SuccessResult
 import com.andone.memorip.presentation.R
 import com.andone.memorip.presentation.groupdetail.component.GalleryTab
 import com.andone.memorip.presentation.groupdetail.component.GroupDetailAppBar
 import com.andone.memorip.presentation.groupdetail.component.MapTab
-import com.andone.memorip.presentation.groupdetail.model.PlaceImageItem
+import com.andone.memorip.presentation.model.ImageItem
+import com.andone.memorip.presentation.model.Place
 import com.andone.memorip.presentation.theme.MemoripTheme
+import com.andone.memorip.presentation.util.DummyData
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+private object MarkerImageConstants {
+    const val WIDTH = 200
+    const val HEIGHT = 200
+    val BITMAP_CONFIG = Bitmap.Config.ARGB_8888
+}
 
 @Composable
 fun GroupDetailScreen(
     onBackClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    // 임시 더미 데이터 생성
-    // todo: 실제 groupId를 가져와서 그룹 정보를 가져와야 함
     val groupName = "Group1"
-    val dummyImages = remember {
-        List(30) { index ->
-            val randomHeight = (150..400).random()
-            val fixedWidth = 200
-            PlaceImageItem(
-                id = index,
-                url = "https://picsum.photos/id/${index + 1}/$fixedWidth/$randomHeight",
-                width = fixedWidth,
-                height = randomHeight
-            )
-        }
-    }
 
     GroupDetailScreenContent(
         groupName = groupName,
-        images = dummyImages,
+        places = DummyData.places,
         onBackClick = onBackClick,
         onSearchClick = { /* TODO: 검색 기능 구현 */ },
         onMenuClick = { /* TODO: 메뉴 기능 구현 */ },
@@ -58,22 +62,51 @@ fun GroupDetailScreen(
 @Composable
 fun GroupDetailScreenContent(
     groupName: String,
-    images: List<PlaceImageItem>,
+    places: List<Place>,
     onBackClick: () -> Unit,
     onSearchClick: () -> Unit,
     onMenuClick: () -> Unit,
     modifier: Modifier = Modifier,
     initialPage: Int = 0
 ) {
+    val context = LocalContext.current
     val tabs = listOf(
         stringResource(R.string.groupdetail_tab_gallery),
         stringResource(R.string.groupdetail_tab_map)
     )
-    val pagerState = rememberPagerState(
-        initialPage = initialPage,
-        pageCount = { tabs.size }
-    )
-    val coroutineScope = rememberCoroutineScope()
+
+    var selectedTabIndex by remember { mutableIntStateOf(initialPage) }
+    
+    // 마커용 이미지 미리 로드
+    val markerImages = remember { mutableStateMapOf<String, Bitmap>() }
+
+    LaunchedEffect(places) {
+        places.forEach { place ->
+            val imageUrl = place.thumbnailImage.url
+
+            launch(Dispatchers.IO) {
+                runCatching {
+                    val imageLoader = ImageLoader(context)
+                    val request = ImageRequest.Builder(context)
+                        .data(imageUrl)
+                        .size(MarkerImageConstants.WIDTH, MarkerImageConstants.HEIGHT)
+                        .allowHardware(false)
+                        .build()
+                    imageLoader.execute(request)
+                }.mapCatching { result ->
+                    (result as? SuccessResult)?.drawable?.toBitmap(
+                        width = MarkerImageConstants.WIDTH,
+                        height = MarkerImageConstants.HEIGHT,
+                        config = MarkerImageConstants.BITMAP_CONFIG
+                    ) ?: error("이미지 로드 실패")
+                }.onSuccess { bitmap ->
+                    withContext(Dispatchers.Main) {
+                        markerImages[imageUrl] = bitmap
+                    }
+                }
+            }
+        }
+    }
 
     Scaffold(
         topBar = {
@@ -92,33 +125,29 @@ fun GroupDetailScreenContent(
                 .padding(innerPadding)
         ) {
             PrimaryTabRow(
-                selectedTabIndex = pagerState.currentPage,
+                selectedTabIndex = selectedTabIndex,
                 modifier = Modifier.fillMaxWidth()
             ) {
                 tabs.forEachIndexed { index, title ->
                     Tab(
-                        selected = pagerState.currentPage == index,
-                        onClick = {
-                            coroutineScope.launch {
-                                pagerState.animateScrollToPage(index)
-                            }
-                        },
+                        selected = selectedTabIndex == index,
+                        onClick = { selectedTabIndex = index },
                         text = { Text(text = title) }
                     )
                 }
             }
 
-            HorizontalPager(
-                state = pagerState,
-                modifier = Modifier.fillMaxSize()
-            ) { page ->
-                when (page) {
-                    0 -> GalleryTab(
-                        images = images,
-                        modifier = Modifier.fillMaxSize()
-                    )
-                    1 -> MapTab(modifier = Modifier.fillMaxSize())
-                }
+            // 선택된 탭에 따라 조건부 렌더링
+            when (selectedTabIndex) {
+                0 -> GalleryTab(
+                    places = places,
+                    modifier = Modifier.fillMaxSize()
+                )
+                1 -> MapTab(
+                    places = places,
+                    markerImages = markerImages,
+                    modifier = Modifier.fillMaxSize()
+                )
             }
         }
     }
@@ -128,22 +157,9 @@ fun GroupDetailScreenContent(
 @Composable
 private fun GroupDetailScreenContentGalleryPreview() {
     MemoripTheme {
-        val dummyImages = remember {
-            List(30) { index ->
-                val randomHeight = (150..400).random()
-                val fixedWidth = 200
-                PlaceImageItem(
-                    id = index,
-                    url = "https://picsum.photos/id/${index + 1}/$fixedWidth/$randomHeight",
-                    width = fixedWidth,
-                    height = randomHeight
-                )
-            }
-        }
-
         GroupDetailScreenContent(
             groupName = "Group1",
-            images = dummyImages,
+            places = DummyData.places,
             onBackClick = {},
             onSearchClick = {},
             onMenuClick = {},
@@ -156,22 +172,9 @@ private fun GroupDetailScreenContentGalleryPreview() {
 @Composable
 private fun GroupDetailScreenContentMapPreview() {
     MemoripTheme {
-        val dummyImages = remember {
-            List(30) { index ->
-                val randomHeight = (150..400).random()
-                val fixedWidth = 200
-                PlaceImageItem(
-                    id = index,
-                    url = "https://picsum.photos/id/${index + 1}/$fixedWidth/$randomHeight",
-                    width = fixedWidth,
-                    height = randomHeight
-                )
-            }
-        }
-
         GroupDetailScreenContent(
             groupName = "Group1",
-            images = dummyImages,
+            places = DummyData.places,
             onBackClick = {},
             onSearchClick = {},
             onMenuClick = {},

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/GroupDetailScreen.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/GroupDetailScreen.kt
@@ -77,7 +77,6 @@ fun GroupDetailScreenContent(
 
     var selectedTabIndex by remember { mutableIntStateOf(initialPage) }
     
-    // 마커용 이미지 미리 로드
     val markerImages = remember { mutableStateMapOf<String, Bitmap>() }
 
     LaunchedEffect(places) {
@@ -137,7 +136,6 @@ fun GroupDetailScreenContent(
                 }
             }
 
-            // 선택된 탭에 따라 조건부 렌더링
             when (selectedTabIndex) {
                 0 -> GalleryTab(
                     places = places,

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/component/GalleryTab.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/component/GalleryTab.kt
@@ -1,22 +1,25 @@
 package com.andone.memorip.presentation.groupdetail.component
 
-import android.content.res.Configuration
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.andone.memorip.presentation.component.MemoripStaggeredGrid
-import com.andone.memorip.presentation.groupdetail.model.PlaceImageItem
+import com.andone.memorip.presentation.model.Place
 import com.andone.memorip.presentation.theme.MemoripTheme
+import com.andone.memorip.presentation.util.DummyData
 
 @Composable
 fun GalleryTab(
-    images: List<PlaceImageItem>,
+    places: List<Place>,
     modifier: Modifier = Modifier
 ) {
+    val thumbnailImages = remember(places) {
+        places.map { it.thumbnailImage }
+    }
     MemoripStaggeredGrid(
-        images = images,
+        images = thumbnailImages,
         modifier = modifier
     )
 }
@@ -25,20 +28,8 @@ fun GalleryTab(
 @Composable
 private fun GalleryTabPreview() {
     MemoripTheme {
-        val dummyImages = remember {
-            List(30) { index ->
-                val randomHeight = (150..400).random()
-                val fixedWidth = 200
-                PlaceImageItem(
-                    id = index,
-                    url = "https://picsum.photos/id/${index + 1}/$fixedWidth/$randomHeight",
-                    width = fixedWidth,
-                    height = randomHeight
-                )
-            }
-        }
         GalleryTab(
-            images = dummyImages,
+            places = DummyData.places,
             modifier = Modifier.fillMaxSize()
         )
     }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/component/ImageMarker.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/component/ImageMarker.kt
@@ -35,7 +35,7 @@ fun ImageMarker(
     imageBitmap: Bitmap,
     modifier: Modifier = Modifier
 ) {
-    val borderColor = MemoripTheme.colors.offWhite
+    val borderColor = MemoripTheme.colors.primaryContainer
 
     Box(
         modifier = modifier.size(
@@ -44,7 +44,6 @@ fun ImageMarker(
         ),
         contentAlignment = Alignment.TopCenter
     ) {
-        // Border 역할을 하는 바깥 Box
         Box(
             modifier = Modifier
                 .size(ImageMarkerDimen.ImageSize + MemoripPadding.PaddingXXSmall)
@@ -52,7 +51,6 @@ fun ImageMarker(
                 .background(borderColor),
             contentAlignment = Alignment.Center
         ) {
-            // 미리 로드된 Bitmap 사용
             Image(
                 bitmap = imageBitmap.asImageBitmap(),
                 contentDescription = null,

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/component/ImageMarker.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/component/ImageMarker.kt
@@ -1,0 +1,100 @@
+package com.andone.memorip.presentation.groupdetail.component
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import com.andone.memorip.presentation.theme.MemoripPadding
+import com.andone.memorip.presentation.theme.MemoripTheme
+
+private object ImageMarkerDimen {
+    val ImageSize: Dp = 48.dp
+    val ShadowElevation: Dp = 4.dp
+    const val ShadowAlpha: Float = 0.25f
+}
+
+@Composable
+fun ImageMarker(
+    imageUrl: String,
+    modifier: Modifier = Modifier
+) {
+    val borderColor = MemoripTheme.colors.offWhite
+
+    Box(
+        modifier = modifier.size(
+            width = ImageMarkerDimen.ImageSize + MemoripPadding.PaddingXXSmall,
+            height = ImageMarkerDimen.ImageSize + MemoripPadding.PaddingXXSmall + MemoripPadding.PaddingXSmall
+        ),
+        contentAlignment = Alignment.TopCenter
+    ) {
+        Box(
+            modifier = Modifier
+                .size(ImageMarkerDimen.ImageSize + MemoripPadding.PaddingXXSmall)
+                .background(
+                    color = borderColor,
+                    shape = RoundedCornerShape(MemoripPadding.PaddingXSmall)
+                )
+                .border(
+                    width = MemoripPadding.PaddingXXXSmall,
+                    color = borderColor,
+                    shape = RoundedCornerShape(MemoripPadding.PaddingXSmall)
+                ),
+            contentAlignment = Alignment.Center
+        ) {
+            AsyncImage(
+                model = ImageRequest.Builder(LocalContext.current)
+                    .data(imageUrl)
+                    .crossfade(true)
+                    .allowHardware(false)
+                    .build(),
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .size(ImageMarkerDimen.ImageSize)
+                    .clip(RoundedCornerShape(MemoripPadding.PaddingXSmall - MemoripPadding.PaddingXXXSmall))
+            )
+        }
+
+        Canvas(
+            modifier = Modifier
+                .size(width = MemoripPadding.PaddingSmall, height = MemoripPadding.PaddingXSmall)
+                .offset(y = ImageMarkerDimen.ImageSize + MemoripPadding.PaddingXXXSmall)
+                .align(Alignment.TopCenter)
+        ) {
+            val path = Path().apply {
+                moveTo(0f, 0f)
+                lineTo(size.width / 2, size.height)
+                lineTo(size.width, 0f)
+                close()
+            }
+            drawPath(
+                path = path,
+                color = borderColor
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun ImageMarkerPreview() {
+    MemoripTheme {
+        ImageMarker(imageUrl = "https://picsum.photos/id/1/200/300")
+    }
+}

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/component/ImageMarker.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/component/ImageMarker.kt
@@ -1,8 +1,9 @@
 package com.andone.memorip.presentation.groupdetail.component
 
+import android.graphics.Bitmap
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
@@ -11,27 +12,27 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import coil.compose.AsyncImage
-import coil.request.ImageRequest
+import androidx.core.content.ContextCompat
+import androidx.core.graphics.drawable.toBitmap
+import com.andone.memorip.presentation.R
 import com.andone.memorip.presentation.theme.MemoripPadding
 import com.andone.memorip.presentation.theme.MemoripTheme
 
 private object ImageMarkerDimen {
     val ImageSize: Dp = 48.dp
-    val ShadowElevation: Dp = 4.dp
-    const val ShadowAlpha: Float = 0.25f
 }
 
 @Composable
 fun ImageMarker(
-    imageUrl: String,
+    imageBitmap: Bitmap,
     modifier: Modifier = Modifier
 ) {
     val borderColor = MemoripTheme.colors.offWhite
@@ -43,34 +44,27 @@ fun ImageMarker(
         ),
         contentAlignment = Alignment.TopCenter
     ) {
+        // Border 역할을 하는 바깥 Box
         Box(
             modifier = Modifier
                 .size(ImageMarkerDimen.ImageSize + MemoripPadding.PaddingXXSmall)
-                .background(
-                    color = borderColor,
-                    shape = RoundedCornerShape(MemoripPadding.PaddingXSmall)
-                )
-                .border(
-                    width = MemoripPadding.PaddingXXXSmall,
-                    color = borderColor,
-                    shape = RoundedCornerShape(MemoripPadding.PaddingXSmall)
-                ),
+                .clip(RoundedCornerShape(MemoripPadding.PaddingXSmall))
+                .background(borderColor),
             contentAlignment = Alignment.Center
         ) {
-            AsyncImage(
-                model = ImageRequest.Builder(LocalContext.current)
-                    .data(imageUrl)
-                    .crossfade(true)
-                    .allowHardware(false)
-                    .build(),
+            // 미리 로드된 Bitmap 사용
+            Image(
+                bitmap = imageBitmap.asImageBitmap(),
                 contentDescription = null,
                 contentScale = ContentScale.Crop,
                 modifier = Modifier
                     .size(ImageMarkerDimen.ImageSize)
                     .clip(RoundedCornerShape(MemoripPadding.PaddingXSmall - MemoripPadding.PaddingXXXSmall))
+                    .background(Color.White)
             )
         }
 
+        // 꼬리
         Canvas(
             modifier = Modifier
                 .size(width = MemoripPadding.PaddingSmall, height = MemoripPadding.PaddingXSmall)
@@ -95,6 +89,9 @@ fun ImageMarker(
 @Composable
 private fun ImageMarkerPreview() {
     MemoripTheme {
-        ImageMarker(imageUrl = "https://picsum.photos/id/1/200/300")
+        val context = LocalContext.current
+        val drawable = ContextCompat.getDrawable(context, R.drawable.ic_launcher_foreground)
+        val bitmap = drawable?.toBitmap(200, 200, Bitmap.Config.ARGB_8888)!!
+        ImageMarker(imageBitmap = bitmap)
     }
 }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/component/MapTab.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/component/MapTab.kt
@@ -10,7 +10,13 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import com.andone.memorip.presentation.R
+import com.andone.memorip.presentation.component.ErrorFullScreen
 import com.andone.memorip.presentation.model.Place
+import com.andone.memorip.presentation.theme.MemoripTheme
+import com.andone.memorip.presentation.util.DummyData
 import com.naver.maps.geometry.LatLng
 import com.naver.maps.geometry.LatLngBounds
 import com.naver.maps.map.CameraUpdate
@@ -23,6 +29,7 @@ import com.naver.maps.map.compose.MarkerComposable
 import com.naver.maps.map.compose.NaverMap
 import com.naver.maps.map.compose.rememberCameraPositionState
 import com.naver.maps.map.compose.rememberUpdatedMarkerState
+import kotlinx.coroutines.delay
 
 @OptIn(ExperimentalNaverMapApi::class)
 @Composable
@@ -33,6 +40,16 @@ fun MapTab(
 ) {
     var selectedPlace by remember { mutableStateOf<Place?>(null) }
     val cameraPositionState = rememberCameraPositionState()
+    var mapLoadError by remember { mutableStateOf(false) }
+    var mapLoaded by remember { mutableStateOf(false) }
+
+    // todo: 맵 화면에 들어올 때 map을 로딩하는게 아니라 갤러리에 들어왔을 때 로딩하는 것으로 변경 고민.
+    LaunchedEffect(Unit) {
+        delay(2000)
+        if (!mapLoaded && !mapLoadError) {
+            mapLoadError = true
+        }
+    }
 
     // 모든 마커가 보이도록 카메라 위치 조정
     AdjustCameraToPlaces(
@@ -41,35 +58,47 @@ fun MapTab(
     )
 
     Box(modifier = modifier) {
-        NaverMap(
-            modifier = Modifier.fillMaxSize(),
-            cameraPositionState = cameraPositionState,
-            properties = remember {
-                MapProperties(
-                    maxZoom = 20.0,
-                    minZoom = 5.0,
-                    locationTrackingMode = LocationTrackingMode.NoFollow
-                )
-            },
-            uiSettings = remember {
-                MapUiSettings(
-                    isLocationButtonEnabled = true,
-                    isZoomControlEnabled = true
+        if (mapLoadError) {
+            ErrorFullScreen(
+                onRetry = {
+                    mapLoadError = false
+                    mapLoaded = false
+                },
+                message = stringResource(R.string.errorfullscreen_error_map_message)
+            )
+        } else {
+            NaverMap(
+                modifier = Modifier.fillMaxSize(),
+                cameraPositionState = cameraPositionState,
+                properties = remember {
+                    MapProperties(
+                        maxZoom = 20.0,
+                        minZoom = 5.0,
+                        locationTrackingMode = LocationTrackingMode.NoFollow
+                    )
+                },
+                uiSettings = remember {
+                    MapUiSettings(
+                        isLocationButtonEnabled = true,
+                        isZoomControlEnabled = true
+                    )
+                },
+                onMapLoaded = { mapLoaded = true },
+                onMapClick = { _, _ -> selectedPlace = null }
+            ) {
+                PlaceMarkers(
+                    places = places,
+                    markerImages = markerImages,
+                    onMarkerClick = { selectedPlace = it }
                 )
             }
-        ) {
-            PlaceMarkers(
-                places = places,
-                markerImages = markerImages,
-                onMarkerClick = { selectedPlace = it }
-            )
-        }
-        selectedPlace?.let { place ->
-            PlaceImagesBottomSheet(
-                placeName = place.name,
-                images = place.images,
-                onDismiss = { selectedPlace = null }
-            )
+            selectedPlace?.let { place ->
+                PlaceImagesBottomSheet(
+                    placeName = place.name,
+                    images = place.images,
+                    onDismiss = { selectedPlace = null }
+                )
+            }
         }
     }
 }
@@ -127,4 +156,26 @@ private fun calculateBounds(places: List<Place>): LatLngBounds {
         LatLng(minLat, minLng),
         LatLng(maxLat, maxLng)
     )
+}
+
+@Preview(name = "Map Tab - Normal", showBackground = true)
+@Composable
+private fun MapTabPreview() {
+    MemoripTheme {
+        MapTab(
+            places = DummyData.places,
+            markerImages = emptyMap(),
+            modifier = Modifier.fillMaxSize()
+        )
+    }
+}
+
+@Preview(name = "Map Tab - Error", showBackground = true)
+@Composable
+private fun MapTabErrorPreview() {
+    MemoripTheme {
+        ErrorFullScreen(
+            onRetry = {},
+        )
+    }
 }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/component/MapTab.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/component/MapTab.kt
@@ -10,11 +10,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
-import com.andone.memorip.presentation.component.FullScreenErrorView
 import com.andone.memorip.presentation.model.Place
-import com.andone.memorip.presentation.theme.MemoripTheme
-import com.andone.memorip.presentation.util.DummyData
 import com.naver.maps.geometry.LatLng
 import com.naver.maps.geometry.LatLngBounds
 import com.naver.maps.map.CameraUpdate
@@ -131,28 +127,4 @@ private fun calculateBounds(places: List<Place>): LatLngBounds {
         LatLng(minLat, minLng),
         LatLng(maxLat, maxLng)
     )
-}
-
-@Preview(name = "Map Tab - Normal", showBackground = true)
-@Composable
-private fun MapTabPreview() {
-    MemoripTheme {
-        MapTab(
-            places = DummyData.places,
-            markerImages = emptyMap(),
-            modifier = Modifier.fillMaxSize()
-        )
-    }
-}
-
-@Preview(name = "Map Tab - Error", showBackground = true)
-@Composable
-private fun MapTabErrorPreview() {
-    MemoripTheme {
-        FullScreenErrorView(
-            title = "지도를 불러올 수 없습니다",
-            message = "지도 인증에 실패했습니다\nNaver Cloud Platform 설정을 확인해주세요",
-            onRetry = {}
-        )
-    }
 }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/component/MapTab.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/component/MapTab.kt
@@ -1,20 +1,158 @@
 package com.andone.memorip.presentation.groupdetail.component
 
-import androidx.compose.material3.Text
+import android.graphics.Bitmap
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import com.andone.memorip.presentation.component.FullScreenErrorView
+import com.andone.memorip.presentation.model.Place
 import com.andone.memorip.presentation.theme.MemoripTheme
+import com.andone.memorip.presentation.util.DummyData
+import com.naver.maps.geometry.LatLng
+import com.naver.maps.geometry.LatLngBounds
+import com.naver.maps.map.CameraUpdate
+import com.naver.maps.map.compose.CameraPositionState
+import com.naver.maps.map.compose.ExperimentalNaverMapApi
+import com.naver.maps.map.compose.LocationTrackingMode
+import com.naver.maps.map.compose.MapProperties
+import com.naver.maps.map.compose.MapUiSettings
+import com.naver.maps.map.compose.MarkerComposable
+import com.naver.maps.map.compose.NaverMap
+import com.naver.maps.map.compose.rememberCameraPositionState
+import com.naver.maps.map.compose.rememberUpdatedMarkerState
 
+@OptIn(ExperimentalNaverMapApi::class)
 @Composable
-fun MapTab(modifier: Modifier = Modifier) {
-    Text("map tab")
+fun MapTab(
+    places: List<Place>,
+    markerImages: Map<String, Bitmap>,
+    modifier: Modifier = Modifier
+) {
+    var selectedPlace by remember { mutableStateOf<Place?>(null) }
+    val cameraPositionState = rememberCameraPositionState()
+
+    // 모든 마커가 보이도록 카메라 위치 조정
+    AdjustCameraToPlaces(
+        places = places,
+        cameraPositionState = cameraPositionState
+    )
+
+    Box(modifier = modifier) {
+        NaverMap(
+            modifier = Modifier.fillMaxSize(),
+            cameraPositionState = cameraPositionState,
+            properties = remember {
+                MapProperties(
+                    maxZoom = 20.0,
+                    minZoom = 5.0,
+                    locationTrackingMode = LocationTrackingMode.NoFollow
+                )
+            },
+            uiSettings = remember {
+                MapUiSettings(
+                    isLocationButtonEnabled = true,
+                    isZoomControlEnabled = true
+                )
+            }
+        ) {
+            PlaceMarkers(
+                places = places,
+                markerImages = markerImages,
+                onMarkerClick = { selectedPlace = it }
+            )
+        }
+        selectedPlace?.let { place ->
+            PlaceImagesBottomSheet(
+                placeName = place.name,
+                images = place.images,
+                onDismiss = { selectedPlace = null }
+            )
+        }
+    }
 }
 
-@Preview(showBackground = true)
+@OptIn(ExperimentalNaverMapApi::class)
+@Composable
+private fun AdjustCameraToPlaces(
+    places: List<Place>,
+    cameraPositionState: CameraPositionState
+) {
+    LaunchedEffect(places) {
+        if (places.isNotEmpty()) {
+            val bounds = calculateBounds(places)
+            val cameraUpdate = CameraUpdate.fitBounds(bounds, 100)
+            cameraPositionState.move(cameraUpdate)
+        }
+    }
+}
+
+@OptIn(ExperimentalNaverMapApi::class)
+@Composable
+private fun PlaceMarkers(
+    places: List<Place>,
+    markerImages: Map<String, Bitmap>,
+    onMarkerClick: (Place) -> Unit
+) {
+    places.forEach { place ->
+        val imageUrl = place.thumbnailImage.url
+        val bitmap = markerImages[imageUrl]
+
+        if (bitmap != null) {
+            MarkerComposable(
+                keys = arrayOf(place.id, imageUrl),
+                state = rememberUpdatedMarkerState(
+                    position = LatLng(place.latitude, place.longitude)
+                ),
+                onClick = {
+                    onMarkerClick(place)
+                    true
+                }
+            ) {
+                ImageMarker(imageBitmap = bitmap)
+            }
+        }
+    }
+}
+
+private fun calculateBounds(places: List<Place>): LatLngBounds {
+    val minLat = places.minOf { it.latitude }
+    val maxLat = places.maxOf { it.latitude }
+    val minLng = places.minOf { it.longitude }
+    val maxLng = places.maxOf { it.longitude }
+
+    return LatLngBounds(
+        LatLng(minLat, minLng),
+        LatLng(maxLat, maxLng)
+    )
+}
+
+@Preview(name = "Map Tab - Normal", showBackground = true)
 @Composable
 private fun MapTabPreview() {
     MemoripTheme {
-        MapTab()
+        MapTab(
+            places = DummyData.places,
+            markerImages = emptyMap(),
+            modifier = Modifier.fillMaxSize()
+        )
+    }
+}
+
+@Preview(name = "Map Tab - Error", showBackground = true)
+@Composable
+private fun MapTabErrorPreview() {
+    MemoripTheme {
+        FullScreenErrorView(
+            title = "지도를 불러올 수 없습니다",
+            message = "지도 인증에 실패했습니다\nNaver Cloud Platform 설정을 확인해주세요",
+            onRetry = {}
+        )
     }
 }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/component/MapTab.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/component/MapTab.kt
@@ -25,10 +25,8 @@ import com.naver.maps.map.compose.ExperimentalNaverMapApi
 import com.naver.maps.map.compose.LocationTrackingMode
 import com.naver.maps.map.compose.MapProperties
 import com.naver.maps.map.compose.MapUiSettings
-import com.naver.maps.map.compose.MarkerComposable
 import com.naver.maps.map.compose.NaverMap
 import com.naver.maps.map.compose.rememberCameraPositionState
-import com.naver.maps.map.compose.rememberUpdatedMarkerState
 import kotlinx.coroutines.delay
 
 @OptIn(ExperimentalNaverMapApi::class)
@@ -86,7 +84,7 @@ fun MapTab(
                 onMapLoaded = { mapLoaded = true },
                 onMapClick = { _, _ -> selectedPlace = null }
             ) {
-                PlaceMarkers(
+                PlaceImageMarkers(
                     places = places,
                     markerImages = markerImages,
                     onMarkerClick = { selectedPlace = it }
@@ -114,34 +112,6 @@ private fun AdjustCameraToPlaces(
             val bounds = calculateBounds(places)
             val cameraUpdate = CameraUpdate.fitBounds(bounds, 100)
             cameraPositionState.move(cameraUpdate)
-        }
-    }
-}
-
-@OptIn(ExperimentalNaverMapApi::class)
-@Composable
-private fun PlaceMarkers(
-    places: List<Place>,
-    markerImages: Map<String, Bitmap>,
-    onMarkerClick: (Place) -> Unit
-) {
-    places.forEach { place ->
-        val imageUrl = place.thumbnailImage.url
-        val bitmap = markerImages[imageUrl]
-
-        if (bitmap != null) {
-            MarkerComposable(
-                keys = arrayOf(place.id, imageUrl),
-                state = rememberUpdatedMarkerState(
-                    position = LatLng(place.latitude, place.longitude)
-                ),
-                onClick = {
-                    onMarkerClick(place)
-                    true
-                }
-            ) {
-                ImageMarker(imageBitmap = bitmap)
-            }
         }
     }
 }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/component/PlaceImageMarkers.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/component/PlaceImageMarkers.kt
@@ -1,0 +1,38 @@
+package com.andone.memorip.presentation.groupdetail.component
+
+import android.graphics.Bitmap
+import androidx.compose.runtime.Composable
+import com.andone.memorip.presentation.component.ImageMarker
+import com.andone.memorip.presentation.model.Place
+import com.naver.maps.geometry.LatLng
+import com.naver.maps.map.compose.ExperimentalNaverMapApi
+import com.naver.maps.map.compose.MarkerComposable
+import com.naver.maps.map.compose.rememberUpdatedMarkerState
+
+@OptIn(ExperimentalNaverMapApi::class)
+@Composable
+fun PlaceImageMarkers(
+    places: List<Place>,
+    markerImages: Map<String, Bitmap>,
+    onMarkerClick: (Place) -> Unit
+) {
+    places.forEach { place ->
+        val imageUrl = place.thumbnailImage.url
+        val bitmap = markerImages[imageUrl]
+
+        if (bitmap != null) {
+            MarkerComposable(
+                keys = arrayOf(place.id, imageUrl),
+                state = rememberUpdatedMarkerState(
+                    position = LatLng(place.latitude, place.longitude)
+                ),
+                onClick = {
+                    onMarkerClick(place)
+                    true
+                }
+            ) {
+                ImageMarker(imageBitmap = bitmap)
+            }
+        }
+    }
+}

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/component/PlaceImagesBottomSheet.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/component/PlaceImagesBottomSheet.kt
@@ -35,8 +35,11 @@ import com.andone.memorip.presentation.theme.MemoripTheme
 import com.andone.memorip.presentation.util.DummyData
 
 private object PlaceImagesBottomSheetDimens {
-    const val ImageAspectRatio = 1f
     val ImageGridMinSize = 100.dp
+}
+
+private object PlaceImagesBottomSheetConstants {
+    const val ImageAspectRatio = 1f
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -126,7 +129,7 @@ private fun PlaceImageItemCard(
     Box(
         modifier = modifier
             .fillMaxWidth()
-            .aspectRatio(PlaceImagesBottomSheetDimens.ImageAspectRatio)
+            .aspectRatio(PlaceImagesBottomSheetConstants.ImageAspectRatio)
             .clip(MemoripTheme.shapes.roundedSmall)
             .background(MemoripTheme.colors.offWhite)
     ) {

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/component/PlaceImagesBottomSheet.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/component/PlaceImagesBottomSheet.kt
@@ -127,7 +127,7 @@ private fun PlaceImageItemCard(
         modifier = modifier
             .fillMaxWidth()
             .aspectRatio(PlaceImagesBottomSheetDimens.ImageAspectRatio)
-            .clip(MemoripTheme.shapes.defaultCorner)
+            .clip(MemoripTheme.shapes.roundedSmall)
             .background(MemoripTheme.colors.offWhite)
     ) {
         AsyncImage(

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/component/PlaceImagesBottomSheet.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/component/PlaceImagesBottomSheet.kt
@@ -1,0 +1,156 @@
+package com.andone.memorip.presentation.groupdetail.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.painter.ColorPainter
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import com.andone.memorip.presentation.R
+import com.andone.memorip.presentation.model.ImageItem
+import com.andone.memorip.presentation.theme.MemoripAlpha
+import com.andone.memorip.presentation.theme.MemoripPadding
+import com.andone.memorip.presentation.theme.MemoripSpace
+import com.andone.memorip.presentation.theme.MemoripTheme
+import com.andone.memorip.presentation.util.DummyData
+
+private object PlaceImagesBottomSheetDimens {
+    const val ImageAspectRatio = 1f
+    val ImageGridMinSize = 100.dp
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PlaceImagesBottomSheet(
+    placeName: String,
+    images: List<ImageItem>,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = false)
+    
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        modifier = modifier,
+        sheetState = sheetState,
+        containerColor = MemoripTheme.colors.offWhite,
+    ) {
+        PlaceImagesContent(
+            placeName = placeName,
+            images = images
+        )
+    }
+}
+
+@Composable
+private fun PlaceImagesContent(
+    placeName: String,
+    images: List<ImageItem>,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(bottom = MemoripPadding.PaddingXLarge),
+        verticalArrangement = Arrangement.spacedBy(MemoripSpace.SpaceMedium),
+    ) {
+        PlaceImagesHeader(
+            placeName = placeName,
+            imageCount = images.size
+        )
+        
+        LazyVerticalGrid(
+            columns = GridCells.Adaptive(minSize = PlaceImagesBottomSheetDimens.ImageGridMinSize),
+            contentPadding = PaddingValues(horizontal = MemoripPadding.PaddingSmall),
+            verticalArrangement = Arrangement.spacedBy(MemoripSpace.SpaceXSmall),
+            horizontalArrangement = Arrangement.spacedBy(MemoripSpace.SpaceXSmall),
+        ) {
+            items(images) { image ->
+                PlaceImageItemCard(imageUrl = image.url)
+            }
+        }
+    }
+}
+
+@Composable
+private fun PlaceImagesHeader(
+    placeName: String,
+    imageCount: Int,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = MemoripPadding.PaddingMedium),
+        verticalArrangement = Arrangement.spacedBy(MemoripSpace.SpaceXSmall)
+    ) {
+        Text(
+            text = placeName,
+            color = MemoripTheme.colors.onOffWhite,
+            style = MemoripTheme.typography.body1,
+        )
+        
+        Text(
+            text = stringResource(R.string.placeimagebottomsheet_place_image_count, imageCount),
+            color = MemoripTheme.colors.onOffWhite.copy(alpha = MemoripAlpha.SECONDARY),
+            style = MemoripTheme.typography.body2
+        )
+    }
+}
+
+@Composable
+private fun PlaceImageItemCard(
+    imageUrl: String,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .aspectRatio(PlaceImagesBottomSheetDimens.ImageAspectRatio)
+            .clip(MemoripTheme.shapes.defaultCorner)
+            .background(MemoripTheme.colors.offWhite)
+    ) {
+        AsyncImage(
+            model = ImageRequest.Builder(LocalContext.current)
+                .data(imageUrl)
+                .crossfade(true)
+                .build(),
+            contentDescription = null,
+            modifier = Modifier.matchParentSize(),
+            placeholder = ColorPainter(MemoripTheme.colors.offWhite),
+            error = ColorPainter(MemoripTheme.colors.offWhite),
+            contentScale = ContentScale.Crop,
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PlaceImagesContentPreview() {
+    MemoripTheme {
+        PlaceImagesContent(
+            placeName = "에펠탑",
+            images = DummyData.placeImages
+        )
+    }
+}

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/model/ImageItem.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/model/ImageItem.kt
@@ -1,9 +1,9 @@
-package com.andone.memorip.presentation.groupdetail.model
+package com.andone.memorip.presentation.model
 
 import androidx.compose.runtime.Immutable
 
 @Immutable
-data class PlaceImageItem(
+data class ImageItem(
     val id: Int,
     val url: String,
     val width: Int,

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/model/Place.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/model/Place.kt
@@ -1,0 +1,13 @@
+package com.andone.memorip.presentation.model
+
+import androidx.compose.runtime.Immutable
+
+@Immutable
+data class Place(
+    val id: Int,
+    val name: String,
+    val latitude: Double,
+    val longitude: Double,
+    val thumbnailImage: ImageItem,
+    val images: List<ImageItem>
+)

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/theme/Color.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/theme/Color.kt
@@ -11,10 +11,15 @@ val PrimaryContainer = Color(0xFFCDAC9B)
 val Secondary = Color(0xFF36699A)
 val White = Color(0xFFFFFFFF)
 val OffWhite = Color(0xFFF5EDE8)
+val OnOffWhite = Color(0xFF2E2520)
 val Gray = Color(0xFF808080)
 val Black = Color(0xFF000000)
 val Outline = Color(0xFF7A5A4A)
 val Red = Color(0xFFB23A2E)
+
+// Dark 테마용 색상
+val DarkOffWhite = Color(0xFF3A3330)
+val DarkOnOffWhite = Color(0xFFF5EDE8)
 
 @Immutable
 data class MemoripColors(
@@ -24,6 +29,7 @@ data class MemoripColors(
     val background: Color,
     val white: Color,
     val offWhite: Color,
+    val onOffWhite: Color,
     val gray: Color,
     val black: Color,
     val outline: Color,
@@ -37,6 +43,7 @@ internal val lightMemoripColors = MemoripColors(
     background = White,
     white = White,
     offWhite = OffWhite,
+    onOffWhite = OnOffWhite,
     gray = Gray,
     black = Black,
     outline = Outline,
@@ -49,7 +56,8 @@ internal val darkMemoripColors = MemoripColors(
     secondary = Secondary,
     background = White,
     white = White,
-    offWhite = OffWhite,
+    offWhite = DarkOffWhite,
+    onOffWhite = DarkOnOffWhite,
     gray = Gray,
     black = Black,
     outline = Outline,

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/util/DummyData.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/util/DummyData.kt
@@ -7,6 +7,15 @@ import kotlin.random.Random
 object DummyData {
     private const val IMAGES_PER_PLACE = 50
     
+    val placeImages: List<ImageItem> = List(12) { index ->
+        ImageItem(
+            id = index + 1,
+            url = "https://picsum.photos/seed/${index + 1}/800/800",
+            width = 800,
+            height = 800
+        )
+    }
+    
     val places: List<Place> = listOf(
         Triple(37.498095, 127.027610, "브런치 카페"),
         Triple(37.512900, 127.058500, "예쁜 공원"),

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/util/DummyData.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/util/DummyData.kt
@@ -1,0 +1,40 @@
+package com.andone.memorip.presentation.util
+
+import com.andone.memorip.presentation.model.ImageItem
+import com.andone.memorip.presentation.model.Place
+import kotlin.random.Random
+
+object DummyData {
+    private const val IMAGES_PER_PLACE = 50
+    
+    val places: List<Place> = listOf(
+        Triple(37.498095, 127.027610, "브런치 카페"),
+        Triple(37.512900, 127.058500, "예쁜 공원"),
+        Triple(37.517305, 127.047502, "야경 맛집"),
+        Triple(37.505228, 127.050324, "루프탑 바"),
+        Triple(37.508547, 127.062835, "숨은 카페"),
+        Triple(37.495592, 127.028747, "감성 서점")
+    ).mapIndexed { placeIndex, (lat, lng, placeName) ->
+        val images = List(IMAGES_PER_PLACE) { imageIndex ->
+            val photoId = Random.nextInt(30, 81)
+            val randomHeight = Random.nextInt(150, 400)
+            val fixedWidth = 200
+            
+            ImageItem(
+                id = placeIndex * IMAGES_PER_PLACE + imageIndex,
+                url = "https://picsum.photos/id/$photoId/$fixedWidth/$randomHeight",
+                width = fixedWidth,
+                height = randomHeight
+            )
+        }
+
+        Place(
+            id = placeIndex,
+            name = placeName,
+            latitude = lat,
+            longitude = lng,
+            thumbnailImage = images.first(),
+            images = images
+        )
+    }
+}

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/util/DummyData.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/util/DummyData.kt
@@ -1,6 +1,5 @@
 package com.andone.memorip.presentation.util
 
-import com.andone.memorip.presentation.groupdetail.model.PlaceImageItem
 import com.andone.memorip.presentation.home.model.GroupUiModel
 import com.andone.memorip.presentation.placedetail.model.PlaceDetail
 import kotlinx.collections.immutable.persistentListOf
@@ -37,17 +36,6 @@ object DummyData {
         groupName = "크리스마스",
         content = "test content, test content, test content, test content\n test content, test content1\n test content, test content2\n test content, test content3\n test content, test content4\n test content, test content5\n test content, test content6\n test content, test content7\n test content, test content8\n test content, test content9\n test content, test content10\n test content, test content11\n test content, test content12\n test content, test content13\n test content, test content14\n test content, test content15"
     )
-
-    val dummyImages = List(30) { index ->
-        val randomHeight = (150..400).random()
-        val fixedWidth = 200
-        PlaceImageItem(
-            id = index,
-            url = "https://picsum.photos/id/${index + 1}/$fixedWidth/$randomHeight",
-            width = fixedWidth,
-            height = randomHeight
-        )
-    }
 
     val placeImages: List<ImageItem> = List(12) { index ->
         ImageItem(

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/util/DummyData.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/util/DummyData.kt
@@ -76,4 +76,16 @@ object DummyData {
             images = images
         )
     }
+
+    val imageItems = (30..80).map { id ->
+        val randomHeight = (50..400).random()
+        val fixedWidth = 200
+
+        ImageItem(
+            id = id,
+            url = "https://picsum.photos/id/$id/$fixedWidth/$randomHeight",
+            width = fixedWidth,
+            height = randomHeight
+        )
+    }
 }

--- a/client/presentation/src/main/res/values/strings.xml
+++ b/client/presentation/src/main/res/values/strings.xml
@@ -38,6 +38,6 @@
     <!-- ErrorFullScreen -->
     <string name="errorfullscreen_retry_button">다시 시도</string>
     <string name="errorfullscreen_error_default_message">잠시 후 다시 시도해주세요.</string>
-    <string name="errorfullscreen_error_map_auth_message">지도를 불러올 수 없습니다.</string>
+    <string name="errorfullscreen_error_map_message">지도를 불러올 수 없습니다.</string>
 
 </resources>

--- a/client/presentation/src/main/res/values/strings.xml
+++ b/client/presentation/src/main/res/values/strings.xml
@@ -31,4 +31,13 @@
     <string name="groupdetail_menu_button_content_description">메뉴</string>
     <string name="groupdetail_search_button_content_description">검색</string>
 
+    <!-- PlaceImagesBottomSheet -->
+    <string name="placeimagebottomsheet_unknown_place">알 수 없는 장소</string>
+    <string name="placeimagebottomsheet_place_image_count">사진 %d장</string>
+
+    <!-- ErrorFullScreen -->
+    <string name="errorfullscreen_retry_button">다시 시도</string>
+    <string name="errorfullscreen_error_default_message">잠시 후 다시 시도해주세요.</string>
+    <string name="errorfullscreen_error_map_auth_message">지도를 불러올 수 없습니다.</string>
+
 </resources>

--- a/client/settings.gradle.kts
+++ b/client/settings.gradle.kts
@@ -16,6 +16,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven("https://repository.map.naver.com/archive/maven")
     }
 }
 


### PR DESCRIPTION
## 📝 변경 사항
그룹 상세 화면의 지도 탭을 구현하고, 네이버 지도 SDK를 연동하여 장소 위치를 마커로 표시하는 기능을 추가했습니다.

## 🎯 작업 내용
- 네이버 지도 SDK 연동
  - Naver Map SDK, Compose, Location 라이브러리 추가
  - local.properties에서 API 키 주입 설정
  - 위치 권한 추가
- 지도 탭 구현
  - 장소 위치를 지도에 마커로 표시
  - 커스텀 이미지 마커 컴포넌트 (`ImageMarker`) 구현
  - Coil을 이용한 마커 이미지 미리 로드 및 Bitmap 변환
  - 모든 마커가 보이도록 카메라 자동 조정
- 장소 이미지 BottomSheet 구현
  - 마커 클릭 시 장소 이름과 이미지 목록을 보여주는 BottomSheet 표시
  - Grid 레이아웃으로 이미지 목록 표시
- 에러 처리
  - 지도 로딩 실패 시 에러 화면 표시
  - `ErrorFullScreen` 컴포저블 구현 (재시도 기능 포함)
- UI/UX 개선
  - `HorizontalPager`를 조건부 렌더링으로 변경하여 탭 전환 최적화
  - 다크 모드용 색상 추가 (`DarkOffWhite`, `DarkOnOffWhite`)
- 데이터 모델 구조화
  - `Place` 모델 추가 (장소 정보: 이름, 위경도, 이미지)
  - `ImageItem` 모델 위치 변경 (groupdetail/model → model)
  - 더미 데이터에 장소 데이터 추가

## 🔗 관련 이슈
Closes #19

## 📸 스크린샷 (선택사항)
<img width="345" height="759" alt="image" src="https://github.com/user-attachments/assets/b6b30d69-374a-4f44-8cfc-ada316a141e3" />

<img width="348" height="764" alt="image" src="https://github.com/user-attachments/assets/efe38bab-d2db-46bd-867e-db55119ac802" />



## 💬 리뷰어에게
- 네이버 지도 API 키가 필요합니다. `local.properties`에 `NAVER_MAP_NCP_KEY_ID` 설정해주세욤.
- 마커 이미지는 Coil로 미리 로드하여 Bitmap으로 변환하는 방식을 사용했습니다.
- 지도 로딩이 2초 이상 걸릴 경우 에러로 간주하고 에러 화면을 표시합니다.
- 마커 클릭 시 해당 장소의 이미지를 BottomSheet로 볼 수 있습니다.
- 700줄 죄송함다 끊을 수 없었어요