### PR TITLE
[Fix] 장소 주소 엔티티 수정

### DIFF
--- a/server/src/main/kotlin/com/andone/memorip/domain/place/entity/Address.kt
+++ b/server/src/main/kotlin/com/andone/memorip/domain/place/entity/Address.kt
@@ -4,22 +4,22 @@ import jakarta.persistence.Column
 import jakarta.persistence.Embeddable
 
 @Embeddable
-data class Address(
+class Address(
     @Column(name = "region_1depth", nullable = false, length = 20)
-    val region1Depth: String, // 시/도 (ex. 서울)
+    var region1Depth: String, // 시/도 (ex. 서울)
 
     @Column(name = "region_2depth", length = 20)
-    val region2Depth: String? = null, // 구/군 (ex. 강남구)
+    var region2Depth: String? = null, // 구/군 (ex. 강남구)
 
     @Column(name = "region_3depth", length = 20)
-    val region3Depth: String? = null, // 동/읍/면 (ex. 역삼동)
+    var region3Depth: String? = null, // 동/읍/면 (ex. 역삼동)
 
     @Column(name = "full_address", nullable = false, length = 255)
-    val fullAddress: String // 전체 주소
+    var fullAddress: String // 전체 주소
 ) {
-    init {
-        require(region1Depth.isNotBlank()) { "시/도 정보는 필수입니다" }
-        require(fullAddress.isNotBlank()) { "전체 주소는 필수입니다" }
-    }
-    protected constructor() : this("", null, null, "")
+//    init {
+//        require(region1Depth.isNotBlank()) { "시/도 정보는 필수입니다" }
+//        require(fullAddress.isNotBlank()) { "전체 주소는 필수입니다" }
+//    }
+//    protected constructor() : this("", null, null, "")
 }

--- a/server/src/main/kotlin/com/andone/memorip/domain/place/service/PlaceService.kt
+++ b/server/src/main/kotlin/com/andone/memorip/domain/place/service/PlaceService.kt
@@ -8,9 +8,7 @@ import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 
 @Service
-class PlaceService(
-    private val placeRepository: PlaceRepository
-) {
+class PlaceService(private val placeRepository: PlaceRepository) {
     fun getPlaceList(pageable: Pageable): PlaceListResult {
         val page = placeRepository.findAll(pageable)
 


### PR DESCRIPTION
## 📝 변경 사항
Place 엔티티의 Address Embeddable 클래스를 JPA 호환성을 위해 수정했습니다. data class에서 일반 class로 변경하고, 불변 속성을 가변 속성으로 전환하여 JPA의 리플렉션 기반 객체 생성을 지원합니다.

## 🎯 작업 내용
- **Address 클래스 구조 변경**
  - `data class` → `class`로 변경 
  - 모든 속성을 `val` → `var`로 변경 (가변 속성)
  - `init` 블록 및 protected constructor 주석 처리
    - JPA는 기본 생성자를 통해 엔티티를 생성하므로 초기화 검증 로직 제거
- **PlaceService 코드 포맷팅**
  - 생성자 파라미터 한 줄로 정리

## 🔗 관련 이슈
JPA Embeddable 객체 매핑 이슈 해결

## 📸 스크린샷 (선택사항)


## 💬 리뷰어에게
- **변경 이유**: JPA는 리플렉션을 사용해 객체를 생성하는데, data class의 경우 자동 생성된 메서드들이 불변 속성(val)과 함께 문제를 일으킬 수 있습니다
- **검증 로직 제거**: init 블록의 검증 로직을 주석 처리했습니다. 필요시 별도의 Validation 로직 추가를 고려해주세요
- **대안 고려사항**: 
  - Bean Validation(@NotBlank 등) 사용 검토
  - 도메인 레벨에서의 검증 로직 추가
- **주의**: Address가 mutable이 되었으므로, 불변성이 필요한 경우 방어적 복사를 고려해야 합니다