### PR TITLE
[Chore] place id String으로 통일, http 관련 설정 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ client/app/google-services
 local.properties
 client/app/release/
 client/app/google-services.json
+client/app/src/main/res/xml/network_security_config.xml
 
 HELP.md
 build/

--- a/client/app/src/main/AndroidManifest.xml
+++ b/client/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
 
     <application
         android:name=".MemoripApplication"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/client/app/src/main/AndroidManifest.xml
+++ b/client/app/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
 
     <application
         android:name=".MemoripApplication"
-        android:usesCleartextTraffic="true"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/client/app/src/main/AndroidManifest.xml
+++ b/client/app/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
 
     <application
         android:name=".MemoripApplication"
-        android:networkSecurityConfig="@xml/network_security_config"
+        android:usesCleartextTraffic="true"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/client/app/src/main/res/xml/network_security_config.xml
+++ b/client/app/src/main/res/xml/network_security_config.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<network-security-config>
-    <domain-config cleartextTrafficPermitted="true">
-        <domain includeSubdomains="true">49.50.132.94</domain>
-    </domain-config>
-</network-security-config>

--- a/client/app/src/main/res/xml/network_security_config.xml
+++ b/client/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">49.50.132.94</domain>
+    </domain-config>
+</network-security-config>

--- a/client/data/src/main/java/com/andone/memorip/data/common/ApiResult.kt
+++ b/client/data/src/main/java/com/andone/memorip/data/common/ApiResult.kt
@@ -1,11 +1,15 @@
 package com.andone.memorip.data.common
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class ApiResult<T>(
     val data: T? = null,
     val pagination: PaginationInfo? = null,
     val error: ErrorDetail? = null
 ) {
 
+    @Serializable
     data class PaginationInfo(
         val currentPage: Int,
         val totalPages: Int,
@@ -13,6 +17,7 @@ data class ApiResult<T>(
         val hasNext: Boolean
     )
 
+    @Serializable
     data class ErrorDetail(
         val code: String,
         val message: String,

--- a/client/data/src/main/java/com/andone/memorip/data/place/datasource/PlaceListPagingSource.kt
+++ b/client/data/src/main/java/com/andone/memorip/data/place/datasource/PlaceListPagingSource.kt
@@ -15,12 +15,19 @@ class PlaceListPagingSource(
 
         val page = params.key ?: 0
 
+        android.util.Log.d("PlaceListPagingSource", "load 진입 page=$page")
+
         return try {
+
+            android.util.Log.d("PlaceListPagingSource", "load 진입2 page=$page")
+
             val response = service.getPlaces(
                 page = page,
                 size = pageSize,
                 sort = sort
             )
+
+            android.util.Log.d("PlaceListPagingSource", "load 진입 page=$page")
 
             if (response.error != null) {
                 return LoadResult.Error(
@@ -38,6 +45,7 @@ class PlaceListPagingSource(
                 nextKey = if (hasNext) page + 1 else null
             )
         } catch (e: Exception) {
+            android.util.Log.d("에러발생", "$e")
             LoadResult.Error(e)
         }
     }

--- a/client/data/src/main/java/com/andone/memorip/data/place/datasource/PlaceListPagingSource.kt
+++ b/client/data/src/main/java/com/andone/memorip/data/place/datasource/PlaceListPagingSource.kt
@@ -1,5 +1,6 @@
 package com.andone.memorip.data.place.datasource
 
+import android.util.Log
 import com.andone.memorip.domain.model.PlaceListItem
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
@@ -37,6 +38,7 @@ class PlaceListPagingSource(
                 nextKey = if (hasNext) page + 1 else null
             )
         } catch (e: Exception) {
+            Log.d("에러 발생", "$e")
             LoadResult.Error(e)
         }
     }

--- a/client/data/src/main/java/com/andone/memorip/data/place/datasource/PlaceListPagingSource.kt
+++ b/client/data/src/main/java/com/andone/memorip/data/place/datasource/PlaceListPagingSource.kt
@@ -12,22 +12,14 @@ class PlaceListPagingSource(
 ) : PagingSource<Int, PlaceListItem>() {
 
     override suspend fun load(params: LoadParams<Int>): LoadResult<Int, PlaceListItem> {
-
         val page = params.key ?: 0
 
-        android.util.Log.d("PlaceListPagingSource", "load 진입 page=$page")
-
         return try {
-
-            android.util.Log.d("PlaceListPagingSource", "load 진입2 page=$page")
-
             val response = service.getPlaces(
                 page = page,
                 size = pageSize,
                 sort = sort
             )
-
-            android.util.Log.d("PlaceListPagingSource", "load 진입 page=$page")
 
             if (response.error != null) {
                 return LoadResult.Error(
@@ -45,7 +37,6 @@ class PlaceListPagingSource(
                 nextKey = if (hasNext) page + 1 else null
             )
         } catch (e: Exception) {
-            android.util.Log.d("에러발생", "$e")
             LoadResult.Error(e)
         }
     }

--- a/client/data/src/main/java/com/andone/memorip/data/place/model/PlaceListItemResponse.kt
+++ b/client/data/src/main/java/com/andone/memorip/data/place/model/PlaceListItemResponse.kt
@@ -10,7 +10,7 @@ data class PlaceListItemResponse(
     val latitude: Double,
     val longitude: Double,
     val address: String,
-    val imageUrl: String
+    val imageUrl: String? = null
 )
 
 fun PlaceListItemResponse.toDomain(): PlaceListItem =
@@ -20,6 +20,6 @@ fun PlaceListItemResponse.toDomain(): PlaceListItem =
         latitude = latitude,
         longitude = longitude,
         address = address,
-        imageUrl = imageUrl
+        imageUrl = imageUrl ?: ""
     )
 

--- a/client/presentation/src/main/java/com/andone/memorip/navigation/MemoripNavigator.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/navigation/MemoripNavigator.kt
@@ -48,7 +48,7 @@ class MemoripNavigator(
 
     fun navigateToGroupDetail(groupId: Int) = backStack.navigateToGroupDetail(groupId)
 
-    fun navigateToPlaceDetail(placeId: Int) = backStack.navigateToPlaceDetail(placeId)
+    fun navigateToPlaceDetail(placeId: String) = backStack.navigateToPlaceDetail(placeId)
 
     fun popBackStack() = backStack.removeLastOrNull()
 }

--- a/client/presentation/src/main/java/com/andone/memorip/navigation/Route.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/navigation/Route.kt
@@ -25,6 +25,6 @@ data object SelectLocation : NavKey
 data class GroupDetail(val groupId: Int) : NavKey
 
 @Serializable
-data class PlaceDetail(val placeId: Int = 0) : NavKey
+data class PlaceDetail(val placeId: String = "") : NavKey
 
 @Serializable data object PlaceList : NavKey

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/component/MemoripStaggeredGrid.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/component/MemoripStaggeredGrid.kt
@@ -32,7 +32,7 @@ private object StaggeredGridDimens {
 @Composable
 fun MemoripStaggeredGrid(
     places: PlaceItems,
-    onImageClick: (Int) -> Unit,
+    onImageClick: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     LazyVerticalStaggeredGrid(

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/GroupDetailNavGraph.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/GroupDetailNavGraph.kt
@@ -12,7 +12,7 @@ fun NavBackStack<NavKey>.navigateToGroupDetail(groupId: Int) {
 
 fun EntryProviderScope<NavKey>.groupDetail(
     onNavigateBack: () -> Unit,
-    onImageClick: (Int) -> Unit,
+    onImageClick: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     entry<GroupDetail> { route ->

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/GroupDetailScreen.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/GroupDetailScreen.kt
@@ -50,7 +50,7 @@ private object MarkerImageConstants {
 @Composable
 fun GroupDetailScreen(
     onBackClick: () -> Unit,
-    onImageClick: (Int) -> Unit,
+    onImageClick: (String) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: GroupDetailViewModel = hiltViewModel()
 ) {
@@ -63,7 +63,7 @@ fun GroupDetailScreen(
             }
 
             is GroupDetailEvent.NavigatePlaceDetail -> {
-                onImageClick(event.id.toInt())
+                onImageClick(event.id)
             }
         }
     }
@@ -162,7 +162,7 @@ fun GroupDetailScreenContent(
             when (currentPage) {
                 0 -> GalleryTab(
                     places = places,
-                    onImageClick = { id -> onAction(GroupDetailAction.OnPlaceClick(id = id.toLong())) },
+                    onImageClick = { id -> onAction(GroupDetailAction.OnPlaceClick(id = id)) },
                     modifier = Modifier.fillMaxSize()
                 )
 

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/component/GalleryTab.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/component/GalleryTab.kt
@@ -13,7 +13,7 @@ import com.andone.memorip.presentation.util.DummyData
 @Composable
 fun GalleryTab(
     places: List<Place>,
-    onImageClick: (Int) -> Unit,
+    onImageClick: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     MemoripStaggeredGrid(

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/model/GroupDetailAction.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/model/GroupDetailAction.kt
@@ -4,7 +4,7 @@ import com.andone.memorip.presentation.model.Place
 
 sealed interface GroupDetailAction {
 
-    data class OnPlaceClick(val id: Long) : GroupDetailAction
+    data class OnPlaceClick(val id: String) : GroupDetailAction
 
     data class OnTabClick(val currentTab: Int) : GroupDetailAction
 

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/model/GroupDetailEvent.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/groupdetail/model/GroupDetailEvent.kt
@@ -4,5 +4,5 @@ interface GroupDetailEvent {
 
     data object NavigateBack : GroupDetailEvent
 
-    data class NavigatePlaceDetail(val id: Long) : GroupDetailEvent
+    data class NavigatePlaceDetail(val id: String) : GroupDetailEvent
 }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/model/Place.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/model/Place.kt
@@ -7,7 +7,7 @@ import java.time.LocalDateTime
 
 @Immutable
 data class Place(
-    val id: Int,
+    val id: String,
     val name: String,
     val latitude: Double,
     val longitude: Double,
@@ -26,7 +26,7 @@ data class Place(
 
     companion object {
         fun empty(): Place = Place(
-            id = 0,
+            id = "",
             name = "",
             latitude = 0.0,
             longitude = 0.0,
@@ -42,7 +42,7 @@ data class Place(
 
 fun PlaceListItem.toUiModel(): Place =
     Place(
-        id = id.toInt(),
+        id = id,
         name = title,
         latitude = latitude,
         longitude = longitude,

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/placedetail/PlaceDetailNavGraph.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/placedetail/PlaceDetailNavGraph.kt
@@ -6,7 +6,7 @@ import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavKey
 import com.andone.memorip.navigation.PlaceDetail
 
-fun NavBackStack<NavKey>.navigateToPlaceDetail(placeId: Int) {
+fun NavBackStack<NavKey>.navigateToPlaceDetail(placeId: String) {
     add(PlaceDetail(placeId))
 }
 

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/placedetail/PlaceDetailViewModel.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/placedetail/PlaceDetailViewModel.kt
@@ -36,7 +36,7 @@ class PlaceDetailViewModel(
         }
     }
 
-    fun loadPlaceDetail(id: Int) {
+    fun loadPlaceDetail(id: String) {
         // 장소 상세 불러오기 api 추가될 예정
         // 우선 더미데이터 사용
         viewModelScope.launch {

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/placelist/PlaceListNavGraph.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/placelist/PlaceListNavGraph.kt
@@ -6,7 +6,7 @@ import androidx.navigation3.runtime.NavKey
 import com.andone.memorip.navigation.PlaceList
 
 fun EntryProviderScope<NavKey>.placeList(
-    onPlaceClick: (Int) -> Unit,
+    onPlaceClick: (String) -> Unit,
     onCreatePlaceClick: () -> Unit,
     modifier: Modifier = Modifier
 ){

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/placelist/PlaceListScreen.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/placelist/PlaceListScreen.kt
@@ -37,7 +37,7 @@ import com.andone.memorip.presentation.placelist.model.PlaceItems
 
 @Composable
 fun PlaceListScreen(
-    onPlaceClick: (Int) -> Unit,
+    onPlaceClick: (String) -> Unit,
     onCreatePlaceClick: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: PlaceListViewModel = hiltViewModel(),

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/placelist/model/PlaceListAction.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/placelist/model/PlaceListAction.kt
@@ -4,7 +4,7 @@ sealed interface PlaceListAction {
 
     data object OnFABClick : PlaceListAction
 
-    data class OnPlaceClick(val id: Int) : PlaceListAction
+    data class OnPlaceClick(val id: String) : PlaceListAction
 
     data class OnQueryChange(val query: String) : PlaceListAction
 }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/placelist/model/PlaceListEvent.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/placelist/model/PlaceListEvent.kt
@@ -4,7 +4,7 @@ sealed interface PlaceListEvent {
 
     data object NavigateToPlaceCreate : PlaceListEvent
 
-    data class NavigatePlaceDetail(val id: Int) : PlaceListEvent
+    data class NavigatePlaceDetail(val id: String) : PlaceListEvent
 
     data object ShowSnackBar : PlaceListEvent
 }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/util/DummyData.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/util/DummyData.kt
@@ -58,7 +58,7 @@ object DummyData {
         buildList {
             add(
                 createPlace(
-                    1,
+                    "",
                     "브런치 카페",
                     37.498095,
                     127.027610,
@@ -70,7 +70,7 @@ object DummyData {
             )
             add(
                 createPlace(
-                    2,
+                    "",
                     "예쁜 공원",
                     37.512900,
                     127.058500,
@@ -82,7 +82,7 @@ object DummyData {
             )
             add(
                 createPlace(
-                    3,
+                    "",
                     "야경 맛집",
                     37.517305,
                     127.047502,
@@ -94,7 +94,7 @@ object DummyData {
             )
             add(
                 createPlace(
-                    4,
+                    "",
                     "루프탑 바",
                     37.505228,
                     127.050324,
@@ -106,7 +106,7 @@ object DummyData {
             )
             add(
                 createPlace(
-                    5,
+                    "",
                     "숨은 카페",
                     37.508547,
                     127.062835,
@@ -118,7 +118,7 @@ object DummyData {
             )
             add(
                 createPlace(
-                    6,
+                    "",
                     "감성 서점",
                     37.495592,
                     127.028747,
@@ -131,14 +131,14 @@ object DummyData {
         }
     }
 
-    private fun createPlaceImages(placeId: Int, count: Int = 50): List<ImageItem> {
+    private fun createPlaceImages(placeId: String, count: Int = 50): List<ImageItem> {
         return List(count) { imageIndex ->
             val photoId = Random.nextInt(30, 81)
             val randomHeight = Random.nextInt(150, 400)
             val fixedWidth = 200
 
             ImageItem(
-                id = placeId * count + imageIndex,
+                id = count + imageIndex,
                 url = "https://picsum.photos/id/$photoId/$fixedWidth/$randomHeight",
                 width = fixedWidth,
                 height = randomHeight
@@ -147,7 +147,7 @@ object DummyData {
     }
 
     private fun createPlace(
-        id: Int,
+        id: String,
         name: String,
         latitude: Double,
         longitude: Double,


### PR DESCRIPTION
## 📝 변경 사항
서버의 UUID 기반 Place ID와 클라이언트의 Int 타입 불일치 문제를 해결하고, 로컬 개발 환경에서 HTTP 통신을 허용하도록 Android 네트워크 보안 설정을 추가했습니다.

**노션에 network_security_config 파일 올려뒀습니다 client/app/src/main/res/xml/network_security_config.xml 이렇게 추가해주세요!**

## 🎯 작업 내용

### 🔧 타입 통일 작업
- **Place ID 타입 변경**: `Int` → `String`
  - `Place` 모델의 id 필드 타입 변경
  - 네비게이션 관련 파라미터 타입 변경 (`PlaceDetail`, `MemoripNavigator`)
  - ViewModel, Action, Event 타입 시그니처 수정
  - 더미 데이터 생성 로직 업데이트
- **전체 영향 범위**
  - Presentation Layer: 10개 파일
  - Navigation: 3개 파일
  - Model: 1개 파일

### 🌐 네트워크 보안 설정
- **HTTP 통신 허용 설정 추가**
  - `network_security_config.xml` 생성
  - 개발 서버 IP(49.50.132.94)에 대해 cleartext 트래픽 허용
  - AndroidManifest.xml에 보안 설정 연결

### 📦 직렬화 지원
- **ApiResult 클래스 Serializable 추가**
  - `@Serializable` 어노테이션 추가 (ApiResult, PaginationInfo, ErrorDetail)
  - Kotlin Serialization 지원

## 🔗 관련 이슈
관련 마일스톤: 장소 가져오기

## 📸 스크린샷 (선택사항)
<img width="423" height="893" alt="image" src="https://github.com/user-attachments/assets/0f8ff148-3245-45dd-ae79-de7b4279686c" />

서버 데이터 다음과 같이 나옵니다 이미지 크기 관련 작업이랑, 그리드 아이템 ui 작업 마저 하겠습니다


## 💬 리뷰어에게
- **보안 주의사항**: `network_security_config.xml`의 cleartext 트래픽 허용은 개발 환경에서만 사용해야 합니다. 프로덕션 배포 시 반드시 제거하거나 HTTPS 전환이 필요합니다
- **타입 변경 범위**: Place ID 타입 변경으로 인해 전체 프레젠테이션 레이어에 걸쳐 수정이 이루어졌습니다. 타입 안정성 확인이 필요합니다
- **TODO**: 
  - 프로덕션 배포 전 HTTPS 적용 및 cleartext 트래픽 설정 제거