### PR TITLE
[Feature] place list filter ui 구현

### DIFF
--- a/client/presentation/src/main/java/com/andone/memorip/presentation/component/MemoripStaggeredGrid.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/component/MemoripStaggeredGrid.kt
@@ -84,7 +84,6 @@ private fun StaggeredImageItem(
             imageUrl = imageUrl,
             contentDescription = contentDescription,
             modifier = Modifier.fillMaxWidth(),
-            contentScale = ContentScale.FillWidth
         )
     }
 }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/component/StaticChip.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/component/StaticChip.kt
@@ -48,7 +48,6 @@ fun StaticChip(
     colors: StaticChipColors = StaticChipColors.Default,
     textStyle: TextStyle = MemoripTheme.typography.label1,
     elevation: Dp = 0.dp,
-    onClick: () -> Unit = {}
 ) {
     val borderModifier = if (colors.borderColor != null) {
         modifier.border(
@@ -61,9 +60,7 @@ fun StaticChip(
     }
 
     Surface(
-        modifier = modifier
-            .then(other = borderModifier)
-            .clickable(onClick = onClick),
+        modifier = modifier.then(other = borderModifier),
         shape = RoundedCornerShape(size = radius),
         color = colors.backgroundColor,
         shadowElevation  = elevation

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/component/StaticChip.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/component/StaticChip.kt
@@ -47,6 +47,7 @@ fun StaticChip(
     radius: Dp = StaticChipDimen.RADIUS,
     colors: StaticChipColors = StaticChipColors.Default,
     textStyle: TextStyle = MemoripTheme.typography.label1,
+    elevation: Dp = 0.dp,
     onClick: () -> Unit = {}
 ) {
     val borderModifier = if (colors.borderColor != null) {
@@ -65,6 +66,7 @@ fun StaticChip(
             .clickable(onClick = onClick),
         shape = RoundedCornerShape(size = radius),
         color = colors.backgroundColor,
+        shadowElevation  = elevation
     ) {
         Text(
             text = chipName,

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/component/StaticChip.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/component/StaticChip.kt
@@ -1,6 +1,7 @@
 package com.andone.memorip.presentation.component
 
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -10,6 +11,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -43,7 +45,9 @@ fun StaticChip(
     chipName: String,
     modifier: Modifier = Modifier,
     radius: Dp = StaticChipDimen.RADIUS,
-    colors: StaticChipColors = StaticChipColors.Default
+    colors: StaticChipColors = StaticChipColors.Default,
+    textStyle: TextStyle = MemoripTheme.typography.label1,
+    onClick: () -> Unit = {}
 ) {
     val borderModifier = if (colors.borderColor != null) {
         modifier.border(
@@ -51,10 +55,14 @@ fun StaticChip(
             color = colors.borderColor,
             shape = RoundedCornerShape(radius)
         )
-    } else { modifier }
+    } else {
+        modifier
+    }
 
     Surface(
-        modifier = modifier.then(other = borderModifier),
+        modifier = modifier
+            .then(other = borderModifier)
+            .clickable(onClick = onClick),
         shape = RoundedCornerShape(size = radius),
         color = colors.backgroundColor,
     ) {
@@ -64,7 +72,7 @@ fun StaticChip(
                 horizontal = MemoripPadding.PaddingSmall,
                 vertical = MemoripPadding.PaddingXXSmall
             ),
-            style = MemoripTheme.typography.label1,
+            style = textStyle,
             color = colors.textColor
         )
     }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/component/TagChip.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/component/TagChip.kt
@@ -1,5 +1,6 @@
 package com.andone.memorip.presentation.component
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.Composable

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/placelist/PlaceListScreen.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/placelist/PlaceListScreen.kt
@@ -1,7 +1,8 @@
 package com.andone.memorip.presentation.placelist
 
 import androidx.compose.foundation.gestures.detectTapGestures
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -31,9 +32,13 @@ import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.andone.memorip.presentation.component.MemoripStaggeredGrid
+import com.andone.memorip.presentation.placelist.component.FilterSection
 import com.andone.memorip.presentation.placelist.model.ListPlaceItems
 import com.andone.memorip.presentation.placelist.model.PagingPlaceItems
 import com.andone.memorip.presentation.placelist.model.PlaceItems
+import com.andone.memorip.presentation.theme.MemoripPadding
+import com.andone.memorip.presentation.theme.MemoripSpace
+import kotlinx.collections.immutable.toImmutableList
 
 @Composable
 fun PlaceListScreen(
@@ -103,7 +108,16 @@ fun PlaceListScreenContents(
         floatingActionButton = { AddFloatingActionButton(onClick = { onAction(PlaceListAction.OnFABClick) }) },
         contentWindowInsets = WindowInsets(),
     ) { padding ->
-        Box(modifier = Modifier.padding(paddingValues = padding)) {
+        Column(
+            modifier = Modifier.padding(paddingValues = padding),
+            verticalArrangement = Arrangement.spacedBy(space = MemoripSpace.SpaceMedium)
+        ) {
+            FilterSection(
+                onChangeRegionClick = {},
+                onAddTagClick = {},
+                modifier = Modifier.padding(horizontal = MemoripPadding.PaddingMedium),
+                tags = DummyData.categories.toImmutableList()
+            )
             MemoripStaggeredGrid(
                 places = places,
                 onImageClick = { onAction(PlaceListAction.OnPlaceClick(id = it)) },

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/placelist/PlaceListScreen.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/placelist/PlaceListScreen.kt
@@ -1,8 +1,15 @@
 package com.andone.memorip.presentation.placelist
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -11,6 +18,8 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalFocusManager
@@ -26,12 +35,15 @@ import com.andone.memorip.presentation.theme.MemoripTheme
 import com.andone.memorip.presentation.util.DummyData
 import com.andone.memorip.presentation.util.collectWithLifecycle
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.andone.memorip.presentation.component.MemoripStaggeredGrid
+import com.andone.memorip.presentation.placelist.MemoripMotion.AnimationDuration
+import com.andone.memorip.presentation.placelist.MemoripMotion.ScrollThreshold
 import com.andone.memorip.presentation.placelist.component.FilterSection
 import com.andone.memorip.presentation.placelist.model.ListPlaceItems
 import com.andone.memorip.presentation.placelist.model.PagingPlaceItems
@@ -39,6 +51,11 @@ import com.andone.memorip.presentation.placelist.model.PlaceItems
 import com.andone.memorip.presentation.theme.MemoripPadding
 import com.andone.memorip.presentation.theme.MemoripSpace
 import kotlinx.collections.immutable.toImmutableList
+
+private object MemoripMotion {
+    const val ScrollThreshold = 10
+    const val AnimationDuration = 300
+}
 
 @Composable
 fun PlaceListScreen(
@@ -84,6 +101,8 @@ fun PlaceListScreenContents(
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
     val focusManager = LocalFocusManager.current
 
+    var isFilterVisible by remember { mutableStateOf(true) }
+
     val clearFocusOnScroll = remember {
         object : NestedScrollConnection {
             override fun onPreScroll(
@@ -91,6 +110,14 @@ fun PlaceListScreenContents(
                 source: NestedScrollSource
             ): Offset {
                 focusManager.clearFocus()
+
+                val delta = available.y
+                if (delta < -ScrollThreshold) {
+                    isFilterVisible = false
+                } else if (delta > ScrollThreshold) {
+                    isFilterVisible = true
+                }
+
                 return Offset.Zero
             }
         }
@@ -108,16 +135,24 @@ fun PlaceListScreenContents(
         floatingActionButton = { AddFloatingActionButton(onClick = { onAction(PlaceListAction.OnFABClick) }) },
         contentWindowInsets = WindowInsets(),
     ) { padding ->
-        Column(
-            modifier = Modifier.padding(paddingValues = padding),
-            verticalArrangement = Arrangement.spacedBy(space = MemoripSpace.SpaceMedium)
-        ) {
-            FilterSection(
-                onChangeRegionClick = {},
-                onAddTagClick = {},
-                modifier = Modifier.padding(horizontal = MemoripPadding.PaddingMedium),
-                tags = DummyData.categories.toImmutableList()
-            )
+        Column(modifier = Modifier.padding(paddingValues = padding)) {
+            AnimatedVisibility(
+                visible = isFilterVisible,
+                enter = expandVertically(animationSpec = tween(durationMillis = AnimationDuration)) + fadeIn(),
+                exit = shrinkVertically(animationSpec = tween(durationMillis = AnimationDuration)) + fadeOut()
+            ) {
+                Column {
+                    FilterSection(
+                        onChangeRegionClick = {},
+                        onAddTagClick = {},
+                        modifier = Modifier
+                            .padding(horizontal = MemoripPadding.PaddingMedium),
+                        tags = DummyData.categories.toImmutableList()
+                    )
+                    Spacer(modifier = Modifier.padding(vertical = MemoripPadding.PaddingXSmall))
+                }
+            }
+
             MemoripStaggeredGrid(
                 places = places,
                 onImageClick = { onAction(PlaceListAction.OnPlaceClick(id = it)) },

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/placelist/component/BottomSheetHeader.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/placelist/component/BottomSheetHeader.kt
@@ -1,0 +1,42 @@
+package com.andone.memorip.presentation.placelist.component
+
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import com.andone.memorip.presentation.component.StaticChip
+import com.andone.memorip.presentation.placelist.model.RegionChipModel
+import com.andone.memorip.presentation.theme.MemoripSpace
+import com.andone.memorip.presentation.theme.MemoripTheme
+import com.andone.memorip.presentation.R
+
+@Composable
+fun BottomSheetHeader(
+    onChipClick: (id : String) -> Unit,
+    modifier: Modifier = Modifier,
+    selectedRegions: List<Map<Int, RegionChipModel>> = emptyList(),
+){
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .horizontalScroll(state = rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(space = MemoripSpace.SpaceXSmall)
+    ) {
+        if (selectedRegions.isEmpty()){
+            StaticChip(chipName = stringResource(R.string.place_list_region_default))
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun BottomSheetHeaderPreview(){
+    MemoripTheme {
+        BottomSheetHeader(onChipClick = {})
+    }
+}

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/placelist/component/FilterSection.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/placelist/component/FilterSection.kt
@@ -1,2 +1,51 @@
 package com.andone.memorip.presentation.placelist.component
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.andone.memorip.presentation.model.Category
+import com.andone.memorip.presentation.theme.MemoripSpace
+import com.andone.memorip.presentation.theme.MemoripTheme
+import com.andone.memorip.presentation.util.DummyData
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
+
+@Composable
+fun FilterSection(
+    onChangeRegionClick: () -> Unit,
+    onAddTagClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    tags: ImmutableList<Category> = persistentListOf(),
+    region1: String? = null,
+    region2: String? = null,
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(space = MemoripSpace.SpaceXSmall)
+    ) {
+        LocationFilter(
+            region1 = region1,
+            region2 = region2,
+            onChipClick = {}
+        )
+        TagFilter(
+            tags = tags,
+            onAddTagClick = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun FilterSectionPreview() {
+    MemoripTheme {
+        FilterSection(
+            tags = DummyData.categories.toImmutableList(),
+            onChangeRegionClick = {},
+            onAddTagClick = {},
+        )
+    }
+}

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/placelist/component/FilterSection.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/placelist/component/FilterSection.kt
@@ -2,12 +2,10 @@ package com.andone.memorip.presentation.placelist.component
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.andone.memorip.presentation.model.Category
-import com.andone.memorip.presentation.theme.MemoripPadding
 import com.andone.memorip.presentation.theme.MemoripSpace
 import com.andone.memorip.presentation.theme.MemoripTheme
 import com.andone.memorip.presentation.util.DummyData
@@ -21,16 +19,16 @@ fun FilterSection(
     onAddTagClick: () -> Unit,
     modifier: Modifier = Modifier,
     tags: ImmutableList<Category> = persistentListOf(),
-    region1: String? = null,
-    region2: String? = null,
+    parentRegion: String? = null,
+    childRegion: String? = null,
 ) {
     Column(
         modifier = modifier,
         verticalArrangement = Arrangement.spacedBy(space = MemoripSpace.SpaceXSmall)
     ) {
-        LocationFilter(
-            region1 = region1,
-            region2 = region2,
+        RegionFilter(
+            parentRegion = parentRegion,
+            childRegion = childRegion,
             onChipClick = {}
         )
         TagFilter(

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/placelist/component/FilterSection.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/placelist/component/FilterSection.kt
@@ -1,0 +1,2 @@
+package com.andone.memorip.presentation.placelist.component
+

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/placelist/component/FilterSection.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/placelist/component/FilterSection.kt
@@ -2,10 +2,12 @@ package com.andone.memorip.presentation.placelist.component
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.andone.memorip.presentation.model.Category
+import com.andone.memorip.presentation.theme.MemoripPadding
 import com.andone.memorip.presentation.theme.MemoripSpace
 import com.andone.memorip.presentation.theme.MemoripTheme
 import com.andone.memorip.presentation.util.DummyData

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/placelist/component/LoactionFilter.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/placelist/component/LoactionFilter.kt
@@ -1,14 +1,17 @@
 package com.andone.memorip.presentation.placelist.component
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -17,6 +20,7 @@ import com.andone.memorip.presentation.component.StaticChip
 import com.andone.memorip.presentation.component.StaticChipColors
 import com.andone.memorip.presentation.theme.MemoripSpace
 import com.andone.memorip.presentation.theme.MemoripTheme
+import com.andone.memorip.presentation.theme.memoripShapes
 
 @Composable
 fun LocationFilter(
@@ -32,19 +36,32 @@ fun LocationFilter(
     }
 
     Row(
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(shape = memoripShapes.roundedXSmall)
+            .background(color = MemoripTheme.colors.primaryContainer)
+            .padding(
+                horizontal = MemoripSpace.SpaceSmall,
+                vertical = MemoripSpace.SpaceXSmall
+            ),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(space = MemoripSpace.SpaceXSmall)
     ) {
         Text(
             text = stringResource(R.string.place_list_region),
-            style = MemoripTheme.typography.title2
+            style = MemoripTheme.typography.labelExtBold
         )
-        Text(text = regionText)
+        Text(
+            text = regionText,
+            style = MemoripTheme.typography.label1
+        )
         Spacer(modifier = Modifier.weight(weight = 1f))
         StaticChip(
             chipName = stringResource(R.string.place_list_region_change),
-            colors = StaticChipColors.Default,
+            colors = StaticChipColors.Default.copy(
+                backgroundColor = MemoripTheme.colors.primary,
+                textColor = MemoripTheme.colors.black
+            ),
             textStyle = MemoripTheme.typography.labelExtBold,
             onClick = onChipClick
         )
@@ -53,7 +70,7 @@ fun LocationFilter(
 
 @Preview(showBackground = true)
 @Composable
-private fun LocationFilterPreview(){
+private fun LocationFilterPreview() {
     MemoripTheme {
         Column(
             verticalArrangement = Arrangement.spacedBy(space = 5.dp)
@@ -62,7 +79,7 @@ private fun LocationFilterPreview(){
                 region1 = "서울",
                 region2 = "강남"
             )
-            LocationFilter(region1 = "서울",)
+            LocationFilter(region1 = "서울")
             LocationFilter()
         }
     }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/placelist/component/LoactionFilter.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/placelist/component/LoactionFilter.kt
@@ -1,2 +1,68 @@
 package com.andone.memorip.presentation.placelist.component
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.andone.memorip.presentation.R
+import com.andone.memorip.presentation.component.StaticChip
+import com.andone.memorip.presentation.component.StaticChipColors
+import com.andone.memorip.presentation.theme.MemoripSpace
+import com.andone.memorip.presentation.theme.MemoripTheme
+
+@Composable
+fun LocationFilter(
+    modifier: Modifier = Modifier,
+    region1: String? = null,
+    region2: String? = null,
+    onChipClick: () -> Unit = {}
+) {
+    val regionText = when {
+        region1.isNullOrBlank() -> { stringResource(R.string.place_list_region_default) }
+        region2.isNullOrBlank() -> { region1 }
+        else -> { stringResource(R.string.place_list_region_hierarchy, region1, region2) }
+    }
+
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(space = MemoripSpace.SpaceXSmall)
+    ) {
+        Text(
+            text = stringResource(R.string.place_list_region),
+            style = MemoripTheme.typography.title2
+        )
+        Text(text = regionText)
+        Spacer(modifier = Modifier.weight(weight = 1f))
+        StaticChip(
+            chipName = stringResource(R.string.place_list_region_change),
+            colors = StaticChipColors.Default,
+            textStyle = MemoripTheme.typography.labelExtBold,
+            onClick = onChipClick
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun LocationFilterPreview(){
+    MemoripTheme {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(space = 5.dp)
+        ) {
+            LocationFilter(
+                region1 = "서울",
+                region2 = "강남"
+            )
+            LocationFilter(region1 = "서울",)
+            LocationFilter()
+        }
+    }
+}

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/placelist/component/LoactionFilter.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/placelist/component/LoactionFilter.kt
@@ -1,0 +1,2 @@
+package com.andone.memorip.presentation.placelist.component
+

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/placelist/component/LoactionFilter.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/placelist/component/LoactionFilter.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -31,7 +32,7 @@ fun LocationFilter(
     }
 
     Row(
-        modifier = modifier,
+        modifier = modifier.fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(space = MemoripSpace.SpaceXSmall)
     ) {

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/placelist/component/RegionFilter.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/placelist/component/RegionFilter.kt
@@ -1,6 +1,7 @@
 package com.andone.memorip.presentation.placelist.component
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -58,12 +59,12 @@ fun RegionFilter(
         Spacer(modifier = Modifier.weight(weight = 1f))
         StaticChip(
             chipName = stringResource(R.string.place_list_region_change),
+            modifier = Modifier.clickable(onClick = onChipClick),
             colors = StaticChipColors.Default.copy(
                 backgroundColor = MemoripTheme.colors.primary,
                 textColor = MemoripTheme.colors.black
             ),
             textStyle = MemoripTheme.typography.labelExtBold,
-            onClick = onChipClick
         )
     }
 }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/placelist/component/RegionFilter.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/placelist/component/RegionFilter.kt
@@ -23,16 +23,16 @@ import com.andone.memorip.presentation.theme.MemoripTheme
 import com.andone.memorip.presentation.theme.memoripShapes
 
 @Composable
-fun LocationFilter(
+fun RegionFilter(
     modifier: Modifier = Modifier,
-    region1: String? = null,
-    region2: String? = null,
+    parentRegion: String? = null,
+    childRegion: String? = null,
     onChipClick: () -> Unit = {}
 ) {
     val regionText = when {
-        region1.isNullOrBlank() -> { stringResource(R.string.place_list_region_default) }
-        region2.isNullOrBlank() -> { region1 }
-        else -> { stringResource(R.string.place_list_region_hierarchy, region1, region2) }
+        parentRegion.isNullOrBlank() -> { stringResource(R.string.place_list_region_default) }
+        childRegion.isNullOrBlank() -> { parentRegion }
+        else -> { stringResource(R.string.place_list_region_hierarchy, parentRegion, childRegion) }
     }
 
     Row(
@@ -75,12 +75,12 @@ private fun LocationFilterPreview() {
         Column(
             verticalArrangement = Arrangement.spacedBy(space = 5.dp)
         ) {
-            LocationFilter(
-                region1 = "서울",
-                region2 = "강남"
+            RegionFilter(
+                parentRegion = "서울",
+                childRegion = "강남"
             )
-            LocationFilter(region1 = "서울")
-            LocationFilter()
+            RegionFilter(parentRegion = "서울")
+            RegionFilter()
         }
     }
 }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/placelist/component/RegionSelectBottomSheet.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/placelist/component/RegionSelectBottomSheet.kt
@@ -1,20 +1,28 @@
 package com.andone.memorip.presentation.placelist.component
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import com.andone.memorip.presentation.placelist.model.RegionChipModel
+import com.andone.memorip.presentation.theme.MemoripSpace
 import com.andone.memorip.presentation.theme.MemoripTheme
 
 @Composable
 fun RegionSelectBottomSheet(
-    parentRegions: List<String>,
+    parentRegions: List<RegionChipModel>,
     modifier: Modifier = Modifier,
-    childRegions: List<String> = emptyList(),
-    selectedRegions: List<List<String>> = emptyList(),
-    onConfirmClick: () -> Unit = {}
+    childRegions: List<RegionChipModel> = emptyList(),
+    selectedRegions: List<Map<Int, RegionChipModel>> = emptyList(),
+    onConfirmClick: () -> Unit = {},
+    onRegionClick: (id : String) -> Unit = {},
+    onSelectedRegionClick: (id : String) -> Unit = {}
 ) {
-    Column(modifier = modifier) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(space = MemoripSpace.SpaceMedium)
+    ) {
 
     }
 }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/placelist/component/RegionSelectBottomSheet.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/placelist/component/RegionSelectBottomSheet.kt
@@ -1,0 +1,14 @@
+package com.andone.memorip.presentation.placelist.component
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+fun RegionSelectBottomSheet(
+    parentRegions: List<String>,
+    childRegions: List<String>,
+    modifier: Modifier = Modifier,
+    onConfirmClick: () -> Unit = {}
+) {
+
+}

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/placelist/component/RegionSelectBottomSheet.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/placelist/component/RegionSelectBottomSheet.kt
@@ -1,14 +1,32 @@
 package com.andone.memorip.presentation.placelist.component
 
+import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.andone.memorip.presentation.theme.MemoripTheme
 
 @Composable
 fun RegionSelectBottomSheet(
     parentRegions: List<String>,
-    childRegions: List<String>,
     modifier: Modifier = Modifier,
+    childRegions: List<String> = emptyList(),
+    selectedRegions: List<List<String>> = emptyList(),
     onConfirmClick: () -> Unit = {}
 ) {
+    Column(modifier = modifier) {
 
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun RegionSelectBottomSheetPreview(){
+    MemoripTheme {
+        RegionSelectBottomSheet(
+            parentRegions = emptyList(),
+            childRegions = emptyList(),
+            onConfirmClick = {}
+        )
+    }
 }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/placelist/component/TagFilter.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/placelist/component/TagFilter.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.runtime.Composable
@@ -31,10 +32,13 @@ private object TagFilterDimen {
 @Composable
 fun TagFilter(
     tags: ImmutableList<Category>,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    onAddTagClick: () -> Unit = {}
 ) {
     Row(
-        modifier = modifier.horizontalScroll(state = rememberScrollState()),
+        modifier = modifier
+            .fillMaxWidth()
+            .horizontalScroll(state = rememberScrollState()),
         horizontalArrangement = Arrangement.spacedBy(space = MemoripSpace.SpaceXSmall)
     ) {
         tags.forEach { tag -> TagChip(tag = tag) }
@@ -43,7 +47,7 @@ fun TagFilter(
             colors = StaticChipColors.Default,
             textStyle = MemoripTheme.typography.labelExtBold,
             elevation = ELEVATION,
-            onClick = {}
+            onClick = onAddTagClick
         )
     }
 }
@@ -52,9 +56,7 @@ fun TagFilter(
 @Composable
 private fun TagFilterPreview() {
     MemoripTheme {
-        Box(
-            modifier = Modifier.padding(vertical = 16.dp)
-        ) {
+        Box(modifier = Modifier.padding(vertical = 16.dp)) {
             TagFilter(tags = DummyData.categories.toImmutableList())
         }
     }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/placelist/component/TagFilter.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/placelist/component/TagFilter.kt
@@ -2,12 +2,16 @@ package com.andone.memorip.presentation.placelist.component
 
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import com.andone.memorip.presentation.component.StaticChip
 import com.andone.memorip.presentation.component.StaticChipColors
 import com.andone.memorip.presentation.component.TagChip
@@ -18,6 +22,11 @@ import com.andone.memorip.presentation.util.DummyData
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import com.andone.memorip.presentation.R
+import com.andone.memorip.presentation.placelist.component.TagFilterDimen.ELEVATION
+
+private object TagFilterDimen {
+    val ELEVATION: Dp = 4.dp
+}
 
 @Composable
 fun TagFilter(
@@ -33,15 +42,20 @@ fun TagFilter(
             chipName = stringResource(R.string.place_list_add_tag),
             colors = StaticChipColors.Default,
             textStyle = MemoripTheme.typography.labelExtBold,
+            elevation = ELEVATION,
             onClick = {}
         )
     }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun TagFilterPreview() {
     MemoripTheme {
-        TagFilter(tags = DummyData.categories.toImmutableList())
+        Box(
+            modifier = Modifier.padding(vertical = 16.dp)
+        ) {
+            TagFilter(tags = DummyData.categories.toImmutableList())
+        }
     }
 }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/placelist/component/TagFilter.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/placelist/component/TagFilter.kt
@@ -1,0 +1,47 @@
+package com.andone.memorip.presentation.placelist.component
+
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import com.andone.memorip.presentation.component.StaticChip
+import com.andone.memorip.presentation.component.StaticChipColors
+import com.andone.memorip.presentation.component.TagChip
+import com.andone.memorip.presentation.model.Category
+import com.andone.memorip.presentation.theme.MemoripSpace
+import com.andone.memorip.presentation.theme.MemoripTheme
+import com.andone.memorip.presentation.util.DummyData
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
+import com.andone.memorip.presentation.R
+
+@Composable
+fun TagFilter(
+    tags: ImmutableList<Category>,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier.horizontalScroll(state = rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(space = MemoripSpace.SpaceXSmall)
+    ) {
+        tags.forEach { tag -> TagChip(tag = tag) }
+        StaticChip(
+            chipName = stringResource(R.string.place_list_add_tag),
+            colors = StaticChipColors.Default,
+            textStyle = MemoripTheme.typography.labelExtBold,
+            onClick = {}
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun TagFilterPreview() {
+    MemoripTheme {
+        TagFilter(tags = DummyData.categories.toImmutableList())
+    }
+}

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/placelist/component/TagFilter.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/placelist/component/TagFilter.kt
@@ -44,7 +44,10 @@ fun TagFilter(
         tags.forEach { tag -> TagChip(tag = tag) }
         StaticChip(
             chipName = stringResource(R.string.place_list_add_tag),
-            colors = StaticChipColors.Default,
+            colors = StaticChipColors.Default.copy(
+                backgroundColor = MemoripTheme.colors.primary,
+                textColor = MemoripTheme.colors.black
+            ),
             textStyle = MemoripTheme.typography.labelExtBold,
             elevation = ELEVATION,
             onClick = onAddTagClick

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/placelist/component/TagFilter.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/placelist/component/TagFilter.kt
@@ -1,5 +1,6 @@
 package com.andone.memorip.presentation.placelist.component
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -44,13 +45,13 @@ fun TagFilter(
         tags.forEach { tag -> TagChip(tag = tag) }
         StaticChip(
             chipName = stringResource(R.string.place_list_add_tag),
+            modifier = Modifier.clickable(onClick = onAddTagClick),
             colors = StaticChipColors.Default.copy(
                 backgroundColor = MemoripTheme.colors.primary,
                 textColor = MemoripTheme.colors.black
             ),
             textStyle = MemoripTheme.typography.labelExtBold,
             elevation = ELEVATION,
-            onClick = onAddTagClick
         )
     }
 }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/placelist/model/RegionChipModel.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/placelist/model/RegionChipModel.kt
@@ -1,0 +1,9 @@
+package com.andone.memorip.presentation.placelist.model
+
+import java.util.UUID
+
+data class RegionChipModel(
+    val id: UUID = UUID.randomUUID(),
+    val name: String,
+    val isSelected: Boolean = false,
+)

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/placelist/model/RegionChipModel.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/placelist/model/RegionChipModel.kt
@@ -3,7 +3,8 @@ package com.andone.memorip.presentation.placelist.model
 import java.util.UUID
 
 data class RegionChipModel(
-    val id: UUID = UUID.randomUUID(),
+    val id: String = UUID.randomUUID().toString(),
     val name: String,
+    val level: Int,
     val isSelected: Boolean = false,
 )

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/theme/Shape.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/theme/Shape.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.unit.dp
 
 @Immutable
 data class MemoripShapes(
+    val roundedXXSmall: RoundedCornerShape,
     val roundedXSmall: RoundedCornerShape,
     val roundedSmall: RoundedCornerShape,
     val roundedMedium: RoundedCornerShape,
@@ -17,11 +18,12 @@ data class MemoripShapes(
 )
 
 internal val memoripShapes = MemoripShapes(
-    roundedXSmall = RoundedCornerShape(8.dp),
-    roundedSmall = RoundedCornerShape(12.dp),
-    roundedMedium = RoundedCornerShape(16.dp),
-    roundedLarge = RoundedCornerShape(20.dp),
-    roundedXLarge = RoundedCornerShape(24.dp),
+    roundedXXSmall = RoundedCornerShape(size = 4.dp),
+    roundedXSmall = RoundedCornerShape(size = 8.dp),
+    roundedSmall = RoundedCornerShape(size = 12.dp),
+    roundedMedium = RoundedCornerShape(size = 16.dp),
+    roundedLarge = RoundedCornerShape(size = 20.dp),
+    roundedXLarge = RoundedCornerShape(size = 24.dp),
     roundedMax = CircleShape
 )
 

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/theme/Type.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/theme/Type.kt
@@ -34,6 +34,7 @@ data class MemoripTypography(
     val body2: TextStyle,
     val caption1: TextStyle,
     val hint1: TextStyle,
+    val labelExtBold: TextStyle,
     val label1: TextStyle,
     val number1: TextStyle,
     val labelLarge: TextStyle,
@@ -91,6 +92,12 @@ internal val memoripTypography = MemoripTypography(
     labelLarge = TextStyle(
         fontFamily = NotoSansKR,
         fontWeight = FontWeight.Normal,
+        fontSize = 14.sp,
+        lineHeight = 20.sp
+    ),
+    labelExtBold = TextStyle(
+        fontFamily = NotoSansKR,
+        fontWeight = FontWeight.ExtraBold,
         fontSize = 14.sp,
         lineHeight = 20.sp
     ),

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/theme/Type.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/theme/Type.kt
@@ -115,7 +115,7 @@ internal val memoripTypography = MemoripTypography(
     ),
     title2 = TextStyle(
         fontFamily = NotoSansKR,
-        fontWeight = FontWeight.Normal,
+        fontWeight = FontWeight.SemiBold,
         fontSize = 16.sp,
         lineHeight = 22.sp
     ),

--- a/client/presentation/src/main/res/values/strings.xml
+++ b/client/presentation/src/main/res/values/strings.xml
@@ -100,6 +100,7 @@
 
     <!-- PlaceList -->
     <string name="place_list_search">검색</string>
+    <string name="place_list_add_tag">+태그</string>
 
     <!-- PlanScreen -->
     <string name="plan_location_content_description">위치</string>

--- a/client/presentation/src/main/res/values/strings.xml
+++ b/client/presentation/src/main/res/values/strings.xml
@@ -101,6 +101,11 @@
     <!-- PlaceList -->
     <string name="place_list_search">검색</string>
     <string name="place_list_add_tag">+태그</string>
+    <string name="place_list_region">지역 :</string>
+    <string name="place_list_region_change">변경</string>
+    <string name="place_list_region_default">전체</string>
+    <string name="place_list_region_hierarchy">%1$s &gt; %2$s</string>
+
 
     <!-- PlanScreen -->
     <string name="plan_location_content_description">위치</string>


### PR DESCRIPTION
## 📝 변경 사항
장소 리스트 화면에 지역 및 태그 필터링 UI를 구현했습니다. 스크롤에 반응하여 필터 섹션이 자동으로 숨겨지고 나타나는 애니메이션을 적용하여 사용자 경험을 개선했습니다.

## 🎯 작업 내용

### 🎨 UI 컴포넌트 구현
- **FilterSection**: 전체 필터 영역 컴포넌트
  - LocationFilter와 TagFilter를 포함하는 컨테이너
  - ImmutableList를 사용한 안전한 상태 관리
- **LocationFilter**: 지역 선택 필터
  - 계층적 지역 표시 (시/도 > 구/군)
  - 지역 미선택 시 "전체" 기본값 표시
  - 지역 변경 버튼 포함
  - Primary Container 배경의 라운드 카드 형태
- **TagFilter**: 태그 필터
  - 가로 스크롤 가능한 태그 리스트
  - 태그 추가 버튼 (+태그)
  - Elevation 적용으로 입체감 부여

### ✨ 인터랙션 & 애니메이션
- **스크롤 기반 필터 토글**
  - 아래로 스크롤 시(delta < -10) 필터 숨김
  - 위로 스크롤 시(delta > 10) 필터 표시
  - NestedScrollConnection으로 스크롤 감지
- **부드러운 전환 애니메이션**
  - AnimatedVisibility 사용
  - expandVertically + fadeIn (나타날 때)
  - shrinkVertically + fadeOut (숨겨질 때)
  - 애니메이션 지속 시간: 300ms

### 🔧 공통 컴포넌트 개선
- **StaticChip 확장**
  - `onClick` 콜백 추가 (clickable modifier)
  - `textStyle` 커스터마이징 지원
  - `elevation` 파라미터 추가
- **Design System 확장**
  - `labelExtBold` 타이포그래피 추가 (ExtraBold 14sp)
  - `roundedXXSmall` Shape 추가 (4dp)
  - `title2` 폰트 굵기 조정 (Normal → SemiBold)

### 📝 리소스 추가
- 필터 관련 문자열 리소스 6개 추가
- 다국어 지원 준비 (strings.xml)

### 🐛 버그 수정
- MemoripStaggeredGrid의 불필요한 `contentScale` 속성 제거

## 🔗 관련 이슈
관련 마일스톤: 장소 가져오기

## 📸 스크린샷 (선택사항)


https://github.com/user-attachments/assets/a55c73c5-91ac-4ed9-91c2-7d4185efdfe7




## 💬 리뷰어에게
- **스크롤 임계값**: 현재 10px로 설정되어 있습니다. 사용성 테스트 후 조정이 필요할 수 있습니다
- **필터 기능**: 현재는 UI만 구현되어 있으며, 실제 필터링 로직은 추후 백엔드 연동 시 구현 예정입니다
- **ImmutableList 사용**: Jetpack Compose 권장사항에 따라 kotlinx-collections-immutable 사용
- **애니메이션**: expandVertically/shrinkVertically를 사용하여 자연스러운 높이 변화 구현
- **StaticChip 변경**: 기존 사용처에 영향 없도록 기본값 설정
- **TODO**:
  - 지역 변경 다이얼로그 구현
  - 태그 추가/삭제 기능 구현
  - 필터 적용 로직 연동