### PR TITLE
feat: 그룹 API 엔드포인트 구현 및 관련 기능 추가

### DIFF
--- a/server/src/main/kotlin/com/andone/memorip/common/entity/BaseEntity.kt
+++ b/server/src/main/kotlin/com/andone/memorip/common/entity/BaseEntity.kt
@@ -7,6 +7,6 @@ import java.util.UUID
 abstract class BaseEntity {
     @Id
     @Column(columnDefinition = "UUID")
-    open var id: UUID? = null
+    open lateinit var id: UUID
         protected set
 }

--- a/server/src/main/kotlin/com/andone/memorip/common/exception/ApiExceptionCode.kt
+++ b/server/src/main/kotlin/com/andone/memorip/common/exception/ApiExceptionCode.kt
@@ -18,9 +18,14 @@ enum class CommonExceptionCode(
     INVALID_FILE(HttpStatus.BAD_REQUEST, "지원하지 않는 파일 형식입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부에 문제가 발생했습니다. 다시 시도해주세요."),
 
-    // ex. 도메인 별로
+    // 도메인 별로
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."),
+
     PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "장소를 찾을 수 없습니다."),
+
     GROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "그룹을 찾을 수 없습니다."),
-    INVALID_INVITE_CODE(HttpStatus.BAD_REQUEST, "잘못된 참여코드이거나 만료되었습니다."),
+    GROUP_FORBIDDEN(HttpStatus.FORBIDDEN, "해당 그룹에 대한 권한이 없습니다."),
+    GROUP_CANNOT_DELETE_DEFAULT(HttpStatus.BAD_REQUEST, "기본 그룹은 삭제할 수 없습니다."),
+
     TAG_NOT_FOUND(HttpStatus.NOT_FOUND, "태그를 찾을 수 없습니다.")
 }

--- a/server/src/main/kotlin/com/andone/memorip/common/response/PagedResult.kt
+++ b/server/src/main/kotlin/com/andone/memorip/common/response/PagedResult.kt
@@ -1,0 +1,10 @@
+package com.andone.memorip.common.response
+
+/**
+ * service -> controller 전달용 result
+ */
+data class PagedResult<T>(
+    val content: List<T>,
+    val pagination: ApiResult.PaginationInfo
+)
+

--- a/server/src/main/kotlin/com/andone/memorip/domain/group/controller/GroupController.kt
+++ b/server/src/main/kotlin/com/andone/memorip/domain/group/controller/GroupController.kt
@@ -46,7 +46,7 @@ class GroupController(
         description = """
             visibility가 PUBLIC인 그룹들을 조회합니다.
             
-            **페이지네이션 파라미터:**
+            페이지네이션 파라미터:
             - page: 페이지 번호 (0부터 시작, 기본값: 0)
             - size: 페이지 크기 (기본값: 20)
             - sort: 정렬 기준 (기본값: createdAt,desc)
@@ -75,7 +75,7 @@ class GroupController(
             현재 사용자가 생성한 그룹들을 조회합니다.
             각 그룹에 속한 모든 Place 정보도 함께 반환합니다. (owner 정보는 제외)
             
-            **페이지네이션 파라미터:**
+            페이지네이션 파라미터:
             - page: 페이지 번호 (0부터 시작, 기본값: 0)
             - size: 페이지 크기 (기본값: 20)
             - sort: 정렬 기준 (기본값: createdAt,desc)
@@ -106,9 +106,9 @@ class GroupController(
         description = """
             그룹 정보(제목, 공개 여부)를 수정합니다.
             
-            **권한:** 그룹 소유자만 수정할 수 있습니다.
+            권한: 그룹 소유자만 수정할 수 있습니다.
             
-            **수정 가능 항목:**
+            수정 가능 항목:
             - title: 그룹 제목 (1~50자)
             - visibility: 공개 여부 (PRIVATE, PUBLIC)
         """,
@@ -133,9 +133,9 @@ class GroupController(
         description = """
             그룹을 삭제합니다. (Soft Delete)
             
-            **권한:** 그룹 소유자만 삭제할 수 있습니다.
+            권한: 그룹 소유자만 삭제할 수 있습니다.
             
-            **주의:**
+            주의:
             - 삭제된 그룹은 복구할 수 없습니다
             - 그룹에 속한 Place들도 함께 삭제 처리됩니다
         """,

--- a/server/src/main/kotlin/com/andone/memorip/domain/group/controller/GroupController.kt
+++ b/server/src/main/kotlin/com/andone/memorip/domain/group/controller/GroupController.kt
@@ -1,0 +1,154 @@
+package com.andone.memorip.domain.group.controller
+
+import com.andone.memorip.common.response.ApiResult
+import com.andone.memorip.domain.group.dto.request.GroupCreateRequest
+import com.andone.memorip.domain.group.dto.request.GroupUpdateRequest
+import com.andone.memorip.domain.group.dto.response.GroupResponse
+import com.andone.memorip.domain.group.dto.response.GroupWithPlacesResponse
+import com.andone.memorip.domain.group.service.GroupService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
+import org.springframework.data.web.PageableDefault
+import org.springframework.web.bind.annotation.*
+import java.util.UUID
+
+@RestController
+@Tag(name = "Group API", description = "그룹 관련 API")
+@RequestMapping("/api")
+class GroupController(
+    private val groupService: GroupService
+) {
+
+    @PostMapping("/groups")
+    @Operation(
+        summary = "그룹 생성",
+        description = "새로운 그룹을 생성합니다. (CUSTOM 타입) 생성된 그룹의 전체 정보를 반환합니다.",
+        responses = [
+            ApiResponse(responseCode = "200", description = "성공 - 그룹 생성 완료"),
+            ApiResponse(responseCode = "400", description = "잘못된 요청 - 제목이 비어있거나 50자 초과"),
+            ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없습니다")
+        ]
+    )
+    fun createGroup(
+        @Valid @RequestBody request: GroupCreateRequest
+    ): ApiResult<GroupResponse> {
+        val result = groupService.createGroup(request)
+        return ApiResult.success(result)
+    }
+
+    @GetMapping("/public/groups")
+    @Operation(
+        summary = "공개 그룹 조회",
+        description = """
+            visibility가 PUBLIC인 그룹들을 조회합니다.
+            
+            **페이지네이션 파라미터:**
+            - page: 페이지 번호 (0부터 시작, 기본값: 0)
+            - size: 페이지 크기 (기본값: 20)
+            - sort: 정렬 기준 (기본값: createdAt,desc)
+        """,
+        responses = [
+            ApiResponse(responseCode = "200", description = "성공 - 공개 그룹 목록 조회 완료")
+        ]
+    )
+    fun getPublicGroups(
+        @PageableDefault(
+            page = 0,
+            size = 20,
+            sort = ["createdAt"],
+            direction = Sort.Direction.DESC
+        )
+        pageable: Pageable
+    ): ApiResult<List<GroupResponse>> {
+        val result = groupService.getPublicGroups(pageable)
+        return ApiResult.success(result.content, result.pagination)
+    }
+
+    @GetMapping("/me/groups")
+    @Operation(
+        summary = "내 그룹 조회",
+        description = """
+            현재 사용자가 생성한 그룹들을 조회합니다.
+            각 그룹에 속한 모든 Place 정보도 함께 반환합니다. (owner 정보는 제외)
+            
+            **페이지네이션 파라미터:**
+            - page: 페이지 번호 (0부터 시작, 기본값: 0)
+            - size: 페이지 크기 (기본값: 20)
+            - sort: 정렬 기준 (기본값: createdAt,desc)
+            
+            **주의:** 각 그룹의 모든 Place를 포함하므로 응답 크기가 클 수 있습니다.
+        """,
+        responses = [
+            ApiResponse(responseCode = "200", description = "성공 - 내 그룹 목록 조회 완료"),
+            ApiResponse(responseCode = "404", description = "태그를 찾을 수 없습니다 (데이터 정합성 오류)")
+        ]
+    )
+    fun getMyGroups(
+        @PageableDefault(
+            page = 0,
+            size = 20,
+            sort = ["createdAt"],
+            direction = Sort.Direction.DESC
+        )
+        pageable: Pageable
+    ): ApiResult<List<GroupWithPlacesResponse>> {
+        val result = groupService.getMyGroups(pageable)
+        return ApiResult.success(result.content, result.pagination)
+    }
+
+    @PutMapping("/groups/{groupId}")
+    @Operation(
+        summary = "그룹 수정",
+        description = """
+            그룹 정보(제목, 공개 여부)를 수정합니다.
+            
+            **권한:** 그룹 소유자만 수정할 수 있습니다.
+            
+            **수정 가능 항목:**
+            - title: 그룹 제목 (1~50자)
+            - visibility: 공개 여부 (PRIVATE, PUBLIC)
+        """,
+        responses = [
+            ApiResponse(responseCode = "200", description = "성공 - 그룹 수정 완료"),
+            ApiResponse(responseCode = "400", description = "잘못된 요청 - 제목이 비어있거나 50자 초과"),
+            ApiResponse(responseCode = "403", description = "권한 없음 - 그룹 소유자가 아닙니다"),
+            ApiResponse(responseCode = "404", description = "그룹을 찾을 수 없습니다")
+        ]
+    )
+    fun updateGroup(
+        @PathVariable("groupId") groupId: UUID,
+        @Valid @RequestBody request: GroupUpdateRequest
+    ): ApiResult<Unit> {
+        groupService.updateGroup(groupId, request)
+        return ApiResult.success(Unit)
+    }
+
+    @DeleteMapping("/groups/{groupId}")
+    @Operation(
+        summary = "그룹 삭제",
+        description = """
+            그룹을 삭제합니다. (Soft Delete)
+            
+            **권한:** 그룹 소유자만 삭제할 수 있습니다.
+            
+            **주의:**
+            - 삭제된 그룹은 복구할 수 없습니다
+            - 그룹에 속한 Place들도 함께 삭제 처리됩니다
+        """,
+        responses = [
+            ApiResponse(responseCode = "200", description = "성공 - 그룹 삭제 완료"),
+            ApiResponse(responseCode = "403", description = "권한 없음 - 그룹 소유자가 아닙니다"),
+            ApiResponse(responseCode = "404", description = "그룹을 찾을 수 없습니다")
+        ]
+    )
+    fun deleteGroup(
+        @PathVariable("groupId") groupId: UUID
+    ): ApiResult<Unit> {
+        groupService.deleteGroup(groupId)
+        return ApiResult.success(Unit)
+    }
+}

--- a/server/src/main/kotlin/com/andone/memorip/domain/group/dto/request/GroupCreateRequest.kt
+++ b/server/src/main/kotlin/com/andone/memorip/domain/group/dto/request/GroupCreateRequest.kt
@@ -1,8 +1,15 @@
 package com.andone.memorip.domain.group.dto.request
 
 import com.andone.memorip.domain.group.entity.Visibility
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Size
 
 data class GroupCreateRequest(
+    @field:NotBlank(message = "그룹 제목은 필수입니다")
+    @field:Size(max = 50, message = "그룹 제목은 50자 이하여야 합니다")
     val title: String,
-    val visibility: Visibility = Visibility.PRIVATE
+    
+    @field:NotNull(message = "공개 여부는 필수입니다")
+    var visibility: Visibility = Visibility.PRIVATE
 )

--- a/server/src/main/kotlin/com/andone/memorip/domain/group/dto/request/GroupCreateRequest.kt
+++ b/server/src/main/kotlin/com/andone/memorip/domain/group/dto/request/GroupCreateRequest.kt
@@ -1,0 +1,8 @@
+package com.andone.memorip.domain.group.dto.request
+
+import com.andone.memorip.domain.group.entity.Visibility
+
+data class GroupCreateRequest(
+    val title: String,
+    val visibility: Visibility = Visibility.PRIVATE
+)

--- a/server/src/main/kotlin/com/andone/memorip/domain/group/dto/request/GroupUpdateRequest.kt
+++ b/server/src/main/kotlin/com/andone/memorip/domain/group/dto/request/GroupUpdateRequest.kt
@@ -1,0 +1,8 @@
+package com.andone.memorip.domain.group.dto.request
+
+import com.andone.memorip.domain.group.entity.Visibility
+
+data class GroupUpdateRequest(
+    val title: String,
+    val visibility: Visibility
+)

--- a/server/src/main/kotlin/com/andone/memorip/domain/group/dto/request/GroupUpdateRequest.kt
+++ b/server/src/main/kotlin/com/andone/memorip/domain/group/dto/request/GroupUpdateRequest.kt
@@ -1,8 +1,15 @@
 package com.andone.memorip.domain.group.dto.request
 
 import com.andone.memorip.domain.group.entity.Visibility
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Size
 
 data class GroupUpdateRequest(
+    @field:NotBlank(message = "그룹 제목은 필수입니다")
+    @field:Size(max = 50, message = "그룹 제목은 50자 이하여야 합니다")
     val title: String,
-    val visibility: Visibility
+
+    @field:NotNull(message = "공개 여부는 필수입니다")
+    var visibility: Visibility
 )

--- a/server/src/main/kotlin/com/andone/memorip/domain/group/dto/response/GroupResponse.kt
+++ b/server/src/main/kotlin/com/andone/memorip/domain/group/dto/response/GroupResponse.kt
@@ -1,0 +1,29 @@
+package com.andone.memorip.domain.group.dto.response
+
+import com.andone.memorip.domain.group.entity.Group
+import com.andone.memorip.domain.group.entity.GroupType
+import com.andone.memorip.domain.group.entity.Visibility
+import com.andone.memorip.domain.user.dto.UserResponse
+import com.andone.memorip.domain.user.dto.toUserResponse
+import java.time.LocalDateTime
+import java.util.UUID
+
+data class GroupResponse(
+    val id: UUID,
+    val owner: UserResponse,
+    val title: String,
+    val visibility: Visibility,
+    val type: GroupType,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime
+)
+
+fun Group.toGroupResponse(): GroupResponse = GroupResponse(
+    id = this.id,
+    owner = this.owner.toUserResponse(),
+    title = this.title,
+    visibility = this.visibility,
+    type = this.type,
+    createdAt = this.createdAt,
+    updatedAt = this.updatedAt
+)

--- a/server/src/main/kotlin/com/andone/memorip/domain/group/dto/response/GroupWithPlacesResponse.kt
+++ b/server/src/main/kotlin/com/andone/memorip/domain/group/dto/response/GroupWithPlacesResponse.kt
@@ -1,0 +1,18 @@
+package com.andone.memorip.domain.group.dto.response
+
+import com.andone.memorip.domain.group.entity.GroupType
+import com.andone.memorip.domain.group.entity.Visibility
+import com.andone.memorip.domain.place.dto.PlaceDetailResponse
+import java.time.LocalDateTime
+import java.util.UUID
+
+data class GroupWithPlacesResponse(
+    val id: UUID,
+    val title: String,
+    val visibility: Visibility,
+    val type: GroupType,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime,
+    val places: List<PlaceDetailResponse>
+)
+

--- a/server/src/main/kotlin/com/andone/memorip/domain/group/entity/Group.kt
+++ b/server/src/main/kotlin/com/andone/memorip/domain/group/entity/Group.kt
@@ -23,7 +23,7 @@ enum class GroupType {
 @SQLDelete(sql = "UPDATE groups SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
 @SQLRestriction("deleted_at IS NULL")
 class Group protected constructor(
-    id: UUID? = null,
+    id: UUID,
     owner: User,
     title: String,
     visibility: Visibility = Visibility.PRIVATE,

--- a/server/src/main/kotlin/com/andone/memorip/domain/group/entity/Group.kt
+++ b/server/src/main/kotlin/com/andone/memorip/domain/group/entity/Group.kt
@@ -13,6 +13,11 @@ enum class Visibility {
     PUBLIC
 }
 
+enum class GroupType {
+    DEFAULT,
+    CUSTOM
+}
+
 @Entity
 @Table(name = "groups")
 @SQLDelete(sql = "UPDATE groups SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
@@ -21,7 +26,8 @@ class Group protected constructor(
     id: UUID? = null,
     owner: User,
     title: String,
-    visibility: Visibility = Visibility.PRIVATE
+    visibility: Visibility = Visibility.PRIVATE,
+    type: GroupType = GroupType.CUSTOM
 ) : BaseTimeSyncEntity() {
 
     init {
@@ -42,6 +48,11 @@ class Group protected constructor(
     var visibility: Visibility = visibility
         internal set
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    var type: GroupType = type
+        internal set
+
     fun updateTitle(title: String) {
         require(title.isNotBlank()) { "제목은 필수입니다" }
         require(title.length <= 50) { "제목은 50자 이하여야 합니다" }
@@ -51,19 +62,29 @@ class Group protected constructor(
     fun updateVisibility(visibility: Visibility) {
         this.visibility = visibility
     }
+    fun isOwnedBy(userId: UUID): Boolean {
+        return owner.id == userId
+    }
 
     companion object {
         fun create(
             id: UUID? = null,
             owner: User,
             title: String,
-            visibility: Visibility = Visibility.PRIVATE
+            visibility: Visibility = Visibility.PRIVATE,
+            type: GroupType = GroupType.CUSTOM
         ): Group {
             require(title.isNotBlank()) { "제목은 필수입니다" }
             require(title.length <= 50) { "제목은 50자 이하여야 합니다" }
 
             val generatedId = id ?: UuidV7Generator.generate()
-            return Group(generatedId, owner, title, visibility)
+            return Group(
+                id = generatedId,
+                owner = owner,
+                title = title,
+                visibility = visibility,
+                type = type
+            )
         }
     }
 }

--- a/server/src/main/kotlin/com/andone/memorip/domain/group/repository/GroupRepository.kt
+++ b/server/src/main/kotlin/com/andone/memorip/domain/group/repository/GroupRepository.kt
@@ -1,8 +1,13 @@
 package com.andone.memorip.domain.group.repository
 
 import com.andone.memorip.domain.group.entity.Group
+import com.andone.memorip.domain.group.entity.Visibility
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import java.util.UUID
 
 interface GroupRepository: JpaRepository<Group, UUID> {
+    fun findAllByVisibility(visibility: Visibility, pageable: Pageable): Page<Group>
+    fun findAllByOwnerId(ownerId: UUID, pageable: Pageable): Page<Group>
 }

--- a/server/src/main/kotlin/com/andone/memorip/domain/group/service/GroupService.kt
+++ b/server/src/main/kotlin/com/andone/memorip/domain/group/service/GroupService.kt
@@ -6,7 +6,6 @@ import com.andone.memorip.common.response.ApiResult
 import com.andone.memorip.common.response.PagedResult
 import com.andone.memorip.domain.group.dto.request.GroupCreateRequest
 import com.andone.memorip.domain.group.dto.request.GroupUpdateRequest
-import com.andone.memorip.domain.group.dto.response.GroupListResult
 import com.andone.memorip.domain.group.dto.response.GroupResponse
 import com.andone.memorip.domain.group.dto.response.GroupWithPlacesResponse
 import com.andone.memorip.domain.group.dto.response.toGroupResponse
@@ -63,7 +62,7 @@ class GroupService(
     }
 
     @Transactional(readOnly = true)
-    fun getPublicGroups(pageable: Pageable): GroupListResult {
+    fun getPublicGroups(pageable: Pageable): PagedResult<GroupResponse> {
         val page = groupRepository.findAllByVisibility(Visibility.PUBLIC, pageable)
 
         val content = page.content.map { it.toGroupResponse() }
@@ -75,7 +74,7 @@ class GroupService(
             hasNext = page.hasNext()
         )
 
-        return GroupListResult(content, pagination)
+        return PagedResult(content, pagination)
     }
 
     @Transactional(readOnly = true)

--- a/server/src/main/kotlin/com/andone/memorip/domain/group/service/GroupService.kt
+++ b/server/src/main/kotlin/com/andone/memorip/domain/group/service/GroupService.kt
@@ -1,0 +1,160 @@
+package com.andone.memorip.domain.group.service
+
+import com.andone.memorip.common.exception.BusinessException
+import com.andone.memorip.common.exception.CommonExceptionCode
+import com.andone.memorip.common.response.ApiResult
+import com.andone.memorip.common.response.PagedResult
+import com.andone.memorip.domain.group.dto.request.GroupCreateRequest
+import com.andone.memorip.domain.group.dto.request.GroupUpdateRequest
+import com.andone.memorip.domain.group.dto.response.GroupListResult
+import com.andone.memorip.domain.group.dto.response.GroupResponse
+import com.andone.memorip.domain.group.dto.response.GroupWithPlacesResponse
+import com.andone.memorip.domain.group.dto.response.toGroupResponse
+import com.andone.memorip.domain.group.entity.Group
+import com.andone.memorip.domain.group.entity.GroupType
+import com.andone.memorip.domain.group.entity.Visibility
+import com.andone.memorip.domain.group.repository.GroupRepository
+import com.andone.memorip.domain.place.dto.PlaceDetailResponse
+import com.andone.memorip.domain.place.dto.toTagResponse
+import com.andone.memorip.domain.place.repository.PlaceImageRepository
+import com.andone.memorip.domain.place.repository.PlaceRepository
+import com.andone.memorip.domain.place.repository.PlaceTagRepository
+import com.andone.memorip.domain.user.repository.UserRepository
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Service
+class GroupService(
+    private val groupRepository: GroupRepository,
+    private val userRepository: UserRepository,
+    private val placeRepository: PlaceRepository,
+    private val placeTagRepository: PlaceTagRepository,
+    private val placeImageRepository: PlaceImageRepository
+) {
+    /**
+     * 임시 인증 함수 - 실제 인증 구현 전까지 사용
+     * TODO: 실제 인증 구현 후 제거
+     */
+    private fun getCurrentUserId(): UUID {
+        val tempUserId = UUID.fromString("019b8be0-1fad-71e9-9da0-bc03ada63862")
+        return tempUserId
+    }
+
+    @Transactional
+    fun createGroup(request: GroupCreateRequest): GroupResponse {
+        val currentUserId = getCurrentUserId()
+        val owner = userRepository.findByIdOrNull(currentUserId)
+            ?: throw BusinessException(code = CommonExceptionCode.USER_NOT_FOUND)
+
+        val group = Group.create(
+            owner = owner,
+            title = request.title,
+            visibility = request.visibility,
+            type = GroupType.CUSTOM
+        )
+
+        val savedGroup = groupRepository.save(group)
+        return savedGroup.toGroupResponse()
+    }
+
+    @Transactional(readOnly = true)
+    fun getPublicGroups(pageable: Pageable): GroupListResult {
+        val page = groupRepository.findAllByVisibility(Visibility.PUBLIC, pageable)
+
+        val content = page.content.map { it.toGroupResponse() }
+
+        val pagination = ApiResult.PaginationInfo(
+            currentPage = page.number + 1,
+            totalPages = page.totalPages,
+            totalCount = page.totalElements,
+            hasNext = page.hasNext()
+        )
+
+        return GroupListResult(content, pagination)
+    }
+
+    @Transactional(readOnly = true)
+    fun getMyGroups(pageable: Pageable): PagedResult<GroupWithPlacesResponse> {
+        val currentUserId = getCurrentUserId()
+        val page = groupRepository.findAllByOwnerId(currentUserId, pageable)
+
+        val content = page.content.map { group ->
+            val groupId = group.id
+            
+            val placesPage = placeRepository.findAllByGroupId(
+                groupId,
+                PageRequest.of(0, Int.MAX_VALUE, Sort.by( "id"))
+            )
+            
+            val placeDetails = placesPage.content.map { place ->
+                val placeId = place.id
+                val tags = placeTagRepository.findAllByPlaceId(placeId).map { it.toTagResponse() }
+                val images = placeImageRepository.findAllByPlaceId(placeId).map { it.url }
+
+                PlaceDetailResponse(
+                    placeId = placeId,
+                    writerId = place.writerId,
+                    title = place.title,
+                    tags = tags,
+                    images = images,
+                    content = place.content,
+                    latitude = place.latitude,
+                    longitude = place.longitude,
+                    group = group.toGroupResponse(),
+                    address = place.address
+                )
+            }
+
+            GroupWithPlacesResponse(
+                id = group.id,
+                title = group.title,
+                visibility = group.visibility,
+                type = group.type,
+                createdAt = group.createdAt,
+                updatedAt = group.updatedAt,
+                places = placeDetails
+            )
+        }
+
+        val pagination = ApiResult.PaginationInfo(
+            currentPage = page.number + 1,
+            totalPages = page.totalPages,
+            totalCount = page.totalElements,
+            hasNext = page.hasNext()
+        )
+
+        return PagedResult(content, pagination)
+    }
+
+    @Transactional
+    fun updateGroup(groupId: UUID, request: GroupUpdateRequest) {
+        val currentUserId = getCurrentUserId()
+        val group = groupRepository.findByIdOrNull(groupId)
+            ?: throw BusinessException(code = CommonExceptionCode.GROUP_NOT_FOUND)
+
+        if (!group.isOwnedBy(currentUserId)) {
+            throw BusinessException(code = CommonExceptionCode.GROUP_FORBIDDEN)
+        }
+
+        group.updateTitle(request.title)
+        group.updateVisibility(request.visibility)
+    }
+
+    @Transactional
+    fun deleteGroup(groupId: UUID) {
+        val currentUserId = getCurrentUserId()
+        val group = groupRepository.findByIdOrNull(groupId)
+            ?: throw BusinessException(code = CommonExceptionCode.GROUP_NOT_FOUND)
+
+        if (!group.isOwnedBy(currentUserId)) {
+            throw BusinessException(code = CommonExceptionCode.GROUP_FORBIDDEN)
+        }
+
+        groupRepository.delete(group)
+    }
+}

--- a/server/src/main/kotlin/com/andone/memorip/domain/place/dto/PlaceDetailResponse.kt
+++ b/server/src/main/kotlin/com/andone/memorip/domain/place/dto/PlaceDetailResponse.kt
@@ -2,12 +2,9 @@ package com.andone.memorip.domain.place.dto
 
 import com.andone.memorip.common.exception.BusinessException
 import com.andone.memorip.common.exception.CommonExceptionCode
-import com.andone.memorip.domain.group.entity.Group
-import com.andone.memorip.domain.group.entity.Visibility
+import com.andone.memorip.domain.group.dto.response.GroupResponse
 import com.andone.memorip.domain.place.entity.Address
 import com.andone.memorip.domain.place.entity.PlaceTag
-import com.andone.memorip.domain.user.entity.User
-import java.time.LocalDateTime
 import java.util.UUID
 
 data class PlaceDetailResponse(
@@ -23,26 +20,6 @@ data class PlaceDetailResponse(
     val address: Address
 )
 
-data class GroupResponse(
-    val id: UUID,
-    val owner: User,
-    val title: String,
-    val visibility: Visibility,
-    val createdAt: LocalDateTime,
-    val updatedAt: LocalDateTime,
-    val deletedAt: LocalDateTime?
-)
-
-fun Group.toGroupResponse(): GroupResponse = GroupResponse(
-    id = this.id ?: throw BusinessException(code = CommonExceptionCode.GROUP_NOT_FOUND),
-    owner = this.owner,
-    title = this.title,
-    visibility = this.visibility,
-    createdAt = this.createdAt,
-    updatedAt = this.updatedAt,
-    deletedAt = this.deletedAt
-)
-
 data class TagResponse(
     val id: UUID,
     val color: String,
@@ -50,7 +27,7 @@ data class TagResponse(
 )
 
 fun PlaceTag.toTagResponse(): TagResponse = TagResponse(
-    id = this.tag.id ?: throw BusinessException(code = CommonExceptionCode.TAG_NOT_FOUND),
+    id = this.tag.id,
     color = this.tag.colorHex,
     name = this.tag.name
 )

--- a/server/src/main/kotlin/com/andone/memorip/domain/place/entity/Place.kt
+++ b/server/src/main/kotlin/com/andone/memorip/domain/place/entity/Place.kt
@@ -21,6 +21,7 @@ class Place protected constructor(
     latitude: Double,
     longitude: Double,
     address: Address,
+    thumbnailUrl: String,
     imageUrls: List<String>
 ) : BaseTimeSyncEntity() {
 
@@ -61,7 +62,7 @@ class Place protected constructor(
         internal set
 
     @Column(name = "thumbnail_url", length = 512)
-    var thumbnailUrl: String? = null
+    var thumbnailUrl: String = thumbnailUrl
         internal set
 
     @Column(name = "start_at", columnDefinition = "TIMESTAMPTZ")
@@ -113,11 +114,7 @@ class Place protected constructor(
         newUrls.forEach { addImage(it) }
         
         // 이미지 업데이트 시 첫 번째 이미지를 대표 이미지로 설정
-        if (newUrls.isNotEmpty()) {
-            thumbnailUrl = newUrls.first()
-        } else {
-            thumbnailUrl = null
-        }
+        thumbnailUrl = newUrls.firstOrNull() ?: ""
     }
 
     fun updateThumbnailUrl(url: String) {
@@ -190,21 +187,22 @@ class Place protected constructor(
 
             val generatedId = id ?: UuidV7Generator.generate()
             return Place(
-                generatedId,
-                groupId,
-                writerId,
-                title,
-                content,
-                latitude,
-                longitude,
-                address,
-                imageUrls
+                id = generatedId,
+                groupId = groupId,
+                writerId = writerId,
+                title = title,
+                content = content,
+                latitude = latitude,
+                longitude = longitude,
+                address = address,
+                thumbnailUrl = imageUrls.firstOrNull() ?: "",
+                imageUrls = imageUrls
             ).apply {
                 this.content = content
                 this.parentPlaceId = parentPlaceId
                 this.startAt = startAt
                 this.endAt = endAt
-                // 이미지가 있으면 첫 번째 이미지를 대표 이미지로 설정
+
                 if (imageUrls.isNotEmpty()) {
                     this.thumbnailUrl = imageUrls.first()
                 }

--- a/server/src/main/kotlin/com/andone/memorip/domain/place/entity/Place.kt
+++ b/server/src/main/kotlin/com/andone/memorip/domain/place/entity/Place.kt
@@ -13,7 +13,7 @@ import java.util.UUID
 @SQLDelete(sql = "UPDATE places SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
 @SQLRestriction("deleted_at IS NULL")
 class Place protected constructor(
-    id: UUID? = null,
+    id: UUID,
     groupId: UUID,
     writerId: UUID,
     title: String,

--- a/server/src/main/kotlin/com/andone/memorip/domain/place/entity/Place.kt
+++ b/server/src/main/kotlin/com/andone/memorip/domain/place/entity/Place.kt
@@ -60,6 +60,10 @@ class Place protected constructor(
     var address: Address = address
         internal set
 
+    @Column(name = "thumbnail_url", length = 512)
+    var thumbnailUrl: String? = null
+        internal set
+
     @Column(name = "start_at", columnDefinition = "TIMESTAMPTZ")
     var startAt: LocalDateTime? = null
         internal set
@@ -68,7 +72,6 @@ class Place protected constructor(
     var endAt: LocalDateTime? = null
         internal set
 
-    // 양방향 연관관계 설정: Place의 이미지 컬렉션
     @OneToMany(
         mappedBy = "place",
         cascade = [CascadeType.ALL],
@@ -96,6 +99,11 @@ class Place protected constructor(
     fun addImage(url: String, id: UUID? = null): PlaceImage {
         val newImage = PlaceImage.create(id = id, place = this, url = url)
         images.add(newImage)
+        
+        if (thumbnailUrl == null) {
+            thumbnailUrl = url
+        }
+        
         return newImage
     }
 
@@ -103,6 +111,19 @@ class Place protected constructor(
         // todo: object storage의 사진들 삭제, 추가 로직 넣어서 사용해야 함. -> service에서 할 듯?
         images.clear()
         newUrls.forEach { addImage(it) }
+        
+        // 이미지 업데이트 시 첫 번째 이미지를 대표 이미지로 설정
+        if (newUrls.isNotEmpty()) {
+            thumbnailUrl = newUrls.first()
+        } else {
+            thumbnailUrl = null
+        }
+    }
+
+    fun updateThumbnailUrl(url: String) {
+        require(url.isNotBlank()) { "대표 이미지 URL은 필수입니다" }
+        require(url.length <= 512) { "대표 이미지 URL은 512자 이하여야 합니다" }
+        this.thumbnailUrl = url
     }
 
     fun updateTitle(title: String) {
@@ -183,6 +204,10 @@ class Place protected constructor(
                 this.parentPlaceId = parentPlaceId
                 this.startAt = startAt
                 this.endAt = endAt
+                // 이미지가 있으면 첫 번째 이미지를 대표 이미지로 설정
+                if (imageUrls.isNotEmpty()) {
+                    this.thumbnailUrl = imageUrls.first()
+                }
             }
         }
     }

--- a/server/src/main/kotlin/com/andone/memorip/domain/place/entity/PlaceImage.kt
+++ b/server/src/main/kotlin/com/andone/memorip/domain/place/entity/PlaceImage.kt
@@ -12,7 +12,7 @@ import java.util.UUID
 @SQLDelete(sql = "UPDATE place_images SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
 @SQLRestriction("deleted_at IS NULL")
 class PlaceImage protected constructor(
-    id: UUID? = null,
+    id: UUID,
     place: Place,
     url: String
 ) : BaseTimeEntity() {

--- a/server/src/main/kotlin/com/andone/memorip/domain/place/entity/PlaceTag.kt
+++ b/server/src/main/kotlin/com/andone/memorip/domain/place/entity/PlaceTag.kt
@@ -13,7 +13,7 @@ import java.util.UUID
 @SQLDelete(sql = "UPDATE place_tags SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
 @SQLRestriction("deleted_at IS NULL")
 class PlaceTag protected constructor(
-    id: UUID? = null,
+    id: UUID,
     place: Place,
     tag: Tag
 ) : BaseTimeSyncEntity() {

--- a/server/src/main/kotlin/com/andone/memorip/domain/place/repository/PlaceRepository.kt
+++ b/server/src/main/kotlin/com/andone/memorip/domain/place/repository/PlaceRepository.kt
@@ -1,8 +1,11 @@
 package com.andone.memorip.domain.place.repository
 
 import com.andone.memorip.domain.place.entity.Place
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import java.util.UUID
 
 interface PlaceRepository : JpaRepository<Place, UUID> {
+    fun findAllByGroupId(groupId: UUID, pageable: Pageable): Page<Place>
 }

--- a/server/src/main/kotlin/com/andone/memorip/domain/place/service/PlaceService.kt
+++ b/server/src/main/kotlin/com/andone/memorip/domain/place/service/PlaceService.kt
@@ -4,12 +4,12 @@ import com.andone.memorip.common.exception.BusinessException
 import com.andone.memorip.common.exception.CommonExceptionCode
 import com.andone.memorip.common.response.ApiResult
 import com.andone.memorip.domain.group.repository.GroupRepository
+import com.andone.memorip.domain.group.dto.response.toGroupResponse
 import com.andone.memorip.domain.place.dto.PlaceDetailResponse
 import com.andone.memorip.domain.place.dto.PlaceListResult
 import com.andone.memorip.domain.place.dto.request.PlaceCreateRequest
 import com.andone.memorip.domain.place.dto.response.PlaceCreateResponse
 import com.andone.memorip.domain.place.dto.response.PlaceListItemResponse
-import com.andone.memorip.domain.place.dto.toGroupResponse
 import com.andone.memorip.domain.place.dto.toTagResponse
 import com.andone.memorip.domain.place.entity.Place
 import com.andone.memorip.domain.place.repository.PlaceImageRepository
@@ -38,8 +38,7 @@ class PlaceService(
         val images = placeImageRepository.findAllByPlaceId(id = placeId).map { it.url }
 
         return PlaceDetailResponse(
-            placeId = place.id
-                ?: throw BusinessException(code = CommonExceptionCode.PLACE_NOT_FOUND),
+            placeId = place.id,
             writerId = place.writerId,
             title = place.title,
             tags = tags,
@@ -57,7 +56,7 @@ class PlaceService(
 
         val content = page.content.map { place ->
             PlaceListItemResponse(
-                id = place.id!!,
+                id = place.id,
                 title = place.title,
                 latitude = place.latitude,
                 longitude = place.longitude,
@@ -91,6 +90,6 @@ class PlaceService(
         )
 
         val savedPlace = placeRepository.save(place)
-        return PlaceCreateResponse(savedPlace.id!!)
+        return PlaceCreateResponse(savedPlace.id)
     }
 }

--- a/server/src/main/kotlin/com/andone/memorip/domain/place/service/PlaceService.kt
+++ b/server/src/main/kotlin/com/andone/memorip/domain/place/service/PlaceService.kt
@@ -61,7 +61,7 @@ class PlaceService(
                 latitude = place.latitude,
                 longitude = place.longitude,
                 address = place.address.fullAddress,
-                imageUrl = place.getImages().firstOrNull()?.url
+                imageUrl = place.thumbnailUrl
             )
         }
 

--- a/server/src/main/kotlin/com/andone/memorip/domain/tag/entity/Tag.kt
+++ b/server/src/main/kotlin/com/andone/memorip/domain/tag/entity/Tag.kt
@@ -13,7 +13,7 @@ import java.util.UUID
 @SQLDelete(sql = "UPDATE tags SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
 @SQLRestriction("deleted_at IS NULL")
 class Tag protected constructor(
-    id: UUID? = null,
+    id: UUID,
     name: String,
     colorHex: String
 ) : BaseTimeSyncEntity() {

--- a/server/src/main/kotlin/com/andone/memorip/domain/user/dto/UserResponse.kt
+++ b/server/src/main/kotlin/com/andone/memorip/domain/user/dto/UserResponse.kt
@@ -1,0 +1,16 @@
+package com.andone.memorip.domain.user.dto
+
+import com.andone.memorip.domain.user.entity.User
+import java.util.UUID
+
+data class UserResponse(
+    val id: UUID,
+    val nickname: String,
+    val profileImage: String?
+)
+
+fun User.toUserResponse(): UserResponse = UserResponse(
+    id = this.id,
+    nickname = this.nickname,
+    profileImage = this.profileImage
+)

--- a/server/src/main/kotlin/com/andone/memorip/domain/user/entity/User.kt
+++ b/server/src/main/kotlin/com/andone/memorip/domain/user/entity/User.kt
@@ -14,7 +14,7 @@ import java.util.UUID
 @SQLDelete(sql = "UPDATE users SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
 @SQLRestriction("deleted_at IS NULL")
 class User protected constructor(
-    id: UUID? = null,
+    id: UUID,
     nickname: String,
     profileImage: String?
 ) : BaseTimeSyncEntity() {

--- a/server/src/main/kotlin/com/andone/memorip/domain/user/repository/UserRepository.kt
+++ b/server/src/main/kotlin/com/andone/memorip/domain/user/repository/UserRepository.kt
@@ -1,0 +1,7 @@
+package com.andone.memorip.domain.user.repository
+
+import com.andone.memorip.domain.user.entity.User
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+interface UserRepository : JpaRepository<User, UUID>

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -19,6 +19,7 @@ spring:
     hibernate:
       ddl-auto: update
     show-sql: true
+    open-in-view: false
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
## 📝 변경 사항
그룹 관리를 위한 RESTful API 엔드포인트를 구현하고, 관련된 DTO, Repository, 예외 처리 등의 기능을 추가했습니다.

## 🎯 작업 내용
- GroupController 클래스를 추가하여 그룹 CRUD API 엔드포인트 구현
- GroupCreateRequest, GroupUpdateRequest DTO 추가로 요청 데이터 검증 강화
- GroupResponse DTO를 PlaceDetailResponse에서 분리하여 재사용성 향상
- User 관련 Repository 및 DTO 추가
- ApiExceptionCode에 그룹 및 유저 관련 예외 코드 추가
- Place 엔티티에 thumbnailUrl 필드 추가 및 이미지 업데이트 로직 개선
- Place 엔티티의 id 필드가 non-nullable로 변경된 것을 Service 레이어에 반영
- 그룹 DTO에 추가 validation 어노테이션 적용 및 설명 문구 개선

## 🔗 관련 이슈
Closes #89

## 사진
<img width="70%" alt="image" src="https://github.com/user-attachments/assets/dc3b6d03-17b5-4af0-bcba-00d783412d1d" />


## 💬 리뷰어에게
- GroupController의 API 엔드포인트 좀 분리해두었습니다! 엔드포인트 나눠져 있는 거 확인해주세요.
- Place 엔티티의 thumbnailUrl 필드 추가해두었습니다.
- 기존에 만들어져 있는 place 생성 api 에 그룹 부분 반영하는 내용은 PR 분리해서 올리겠습니다. (내용 너무 길어짐 이슈)