### PR TITLE
[Feature] 장소 추가 화면 UI 수정

### DIFF
--- a/client/gradle/libs.versions.toml
+++ b/client/gradle/libs.versions.toml
@@ -40,6 +40,7 @@ firebase = "34.7.0"
 firebaseCrashlytics = "3.0.6"
 googleServices = "4.4.4"
 detekt = "1.23.8"
+exifinterface = "1.3.6"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -98,6 +99,8 @@ androidx-paging-common = { group = "androidx.paging", name = "paging-common", ve
 androidx-paging-compose = { group = "androidx.paging", name = "paging-compose", version.ref = "paging" }
 
 compose-convention = { module = "com.github.GwonDongHyeon21:compose-convention", version.ref = "composeConvention" }
+
+androidx-exifinterface = { group = "androidx.exifinterface", name = "exifinterface", version.ref = "exifinterface" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/client/presentation/build.gradle.kts
+++ b/client/presentation/build.gradle.kts
@@ -117,6 +117,9 @@ dependencies {
     // Convention
     implementation(libs.compose.convention)
     detektPlugins(libs.compose.convention)
+
+    // EXIF
+    implementation(libs.androidx.exifinterface)
 }
 
 apply(from = providers.gradleProperty("DETEKT_IDE_SETUP_URL").get())

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/component/MainBottomBar.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/component/MainBottomBar.kt
@@ -4,22 +4,24 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.offset
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
-import androidx.compose.material3.NavigationBar
-import androidx.compose.material3.NavigationBarItem
-import androidx.compose.material3.NavigationBarItemDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -34,7 +36,7 @@ import com.andone.memorip.presentation.component.MainBottomBarConstants.DURATION
 import com.andone.memorip.presentation.component.MainBottomBarDimens.buttonOffset
 import com.andone.memorip.presentation.component.MainBottomBarDimens.centerButtonSize
 import com.andone.memorip.presentation.component.MainBottomBarDimens.elevation
-import com.andone.memorip.presentation.theme.MemoripPadding
+import com.andone.memorip.presentation.theme.MemoripHeight
 import com.andone.memorip.presentation.theme.MemoripTheme
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
@@ -58,6 +60,8 @@ fun MainBottomBar(
     onFabClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val bottomPadding = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+
     AnimatedVisibility(
         visible = visible,
         modifier = modifier,
@@ -71,33 +75,36 @@ fun MainBottomBar(
         )
     ) {
         Box(
-            modifier = Modifier.fillMaxWidth(),
-            contentAlignment = Alignment.BottomCenter
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(MemoripHeight.bottomBar + bottomPadding)
+                .background(MemoripTheme.colors.background),
+            contentAlignment = Alignment.TopCenter
         ) {
-            NavigationBar(containerColor = MemoripTheme.colors.background) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(MemoripHeight.bottomBar),
+                horizontalArrangement = Arrangement.SpaceAround,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
                 tabs.forEachIndexed { index, tab ->
                     if (index == tabs.size / 2) {
-                        Spacer(modifier = Modifier.width(width = centerButtonSize + MemoripPadding.PaddingXXXLarge))
+                        Spacer(modifier = Modifier.width(centerButtonSize))
                     }
 
-                    NavigationBarItem(
-                        selected = tab == currentTab,
+                    val iconColor =
+                        if (tab == currentTab) MemoripTheme.colors.primary else MemoripTheme.colors.gray
+
+                    IconButton(
                         onClick = { onTabSelected(tab) },
-                        icon = {
-                            Icon(
-                                painter = painterResource(tab.selectedIconId),
-                                contentDescription = stringResource(tab.titleTextId)
-                            )
-                        },
-//                        label = { Text(text = stringResource(tab.titleTextId)) },
-                        colors = NavigationBarItemDefaults.colors(
-                            selectedIconColor = MemoripTheme.colors.onSurface,
-                            selectedTextColor = MemoripTheme.colors.onSurface,
-                            indicatorColor = MemoripTheme.colors.primaryContainer,
-                            unselectedIconColor = MemoripTheme.colors.gray,
-                            unselectedTextColor = MemoripTheme.colors.gray
-                        ),
-                    )
+                        colors = IconButtonDefaults.iconButtonColors(contentColor = iconColor)
+                    ) {
+                        Icon(
+                            painter = painterResource(tab.selectedIconId),
+                            contentDescription = stringResource(tab.titleTextId)
+                        )
+                    }
                 }
             }
 

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/component/MemoripPagingList.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/component/MemoripPagingList.kt
@@ -25,7 +25,6 @@ fun <T : Any> MemoripPagingList(
     emptyContent: @Composable () -> Unit,
     modifier: Modifier = Modifier,
     staggeredCells: StaggeredGridCells? = null,
-    initialContent: @Composable () -> Unit = {},
     itemContent: @Composable (T) -> Unit
 ) {
     val loadState = pagingItems.loadState
@@ -77,11 +76,7 @@ fun <T : Any> MemoripPagingList(
         }
 
         is LoadState.NotLoading -> {
-            if (loadState.append.endOfPaginationReached) {
-                emptyContent()
-            } else {
-                initialContent()
-            }
+            emptyContent()
         }
     }
 }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/component/MemoripPagingList.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/component/MemoripPagingList.kt
@@ -22,10 +22,10 @@ import com.andone.memorip.presentation.util.handleAppendState
 fun <T : Any> MemoripPagingList(
     pagingItems: LazyPagingItems<T>,
     itemKey: (T) -> Any,
+    emptyContent: @Composable () -> Unit,
     modifier: Modifier = Modifier,
     staggeredCells: StaggeredGridCells? = null,
     initialContent: @Composable () -> Unit = {},
-    emptyContent: @Composable () -> Unit,
     itemContent: @Composable (T) -> Unit
 ) {
     val loadState = pagingItems.loadState
@@ -88,13 +88,12 @@ fun <T : Any> MemoripPagingList(
 
 @Preview(showBackground = true)
 @Composable
-fun MemoripPagingLocationsListPreview() {
+private fun MemoripPagingLocationsListPreview() {
     MemoripPagingList(
         pagingItems = DummyData.getLocationPagingItems(),
         itemKey = { it.id },
-        modifier = Modifier.fillMaxSize(),
-        initialContent = {},
         emptyContent = {},
+        modifier = Modifier.fillMaxSize(),
         itemContent = { location ->
             LocationItem(
                 location = location,
@@ -107,14 +106,13 @@ fun MemoripPagingLocationsListPreview() {
 
 @Preview(showBackground = true)
 @Composable
-fun MemoripPagingPlacesListPreview() {
+private fun MemoripPagingPlacesListPreview() {
     MemoripPagingList(
         pagingItems = DummyData.getPlacePagingItems(),
         itemKey = { it.id },
+        emptyContent = {},
         modifier = Modifier.fillMaxSize(),
         staggeredCells = StaggeredGridCells.Adaptive(160.dp),
-        initialContent = {},
-        emptyContent = {},
         itemContent = { place ->
             val image = place.thumbnailImage
             StaggeredImageItem(

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placecreate/PlaceCreateContainer.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placecreate/PlaceCreateContainer.kt
@@ -174,7 +174,7 @@ fun PlaceCreateMainStep(
                             onCategoryClick = { onStepChange(PlaceCreateStep.SelectCategory) },
                             onLocationClick = { onStepChange(PlaceCreateStep.SelectLocation) },
                             onGroupClick = { onStepChange(PlaceCreateStep.SelectGroup) },
-                            onImageCreate = onNavigateToHome,
+                            onNavigateToHome = onNavigateToHome,
                             viewModel = viewModel
                         )
                     }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placecreate/PlaceCreateScreen.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placecreate/PlaceCreateScreen.kt
@@ -71,7 +71,7 @@ fun PlaceCreateScreen(
     onCategoryClick: () -> Unit,
     onLocationClick: () -> Unit,
     onGroupClick: () -> Unit,
-    onImageCreate: () -> Unit,
+    onNavigateToHome: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: PlaceCreateViewModel = hiltViewModel()
 ) {
@@ -79,7 +79,7 @@ fun PlaceCreateScreen(
 
     viewModel.event.collectWithLifecycle { event ->
         when (event) {
-            PlaceCreateEvent.NavigateToHome -> onImageCreate()
+            PlaceCreateEvent.NavigateToHome -> onNavigateToHome()
             PlaceCreateEvent.NavigateToCategory -> onCategoryClick()
             PlaceCreateEvent.NavigateToLocation -> onLocationClick()
             PlaceCreateEvent.NavigateToGroup -> onGroupClick()
@@ -122,6 +122,12 @@ private fun PlaceCreateScreenContent(
 
     LaunchedEffect(Unit) {
         onAction(PlaceCreateAction.OnImageSelect(uiState.images.first()))
+    }
+
+    LaunchedEffect(uiState.images) {
+        if (uiState.images.isEmpty()) {
+            onAction(PlaceCreateAction.OnLastImageRemove)
+        }
     }
 
     DisposableEffect(Unit) {

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placecreate/PlaceCreateViewModel.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placecreate/PlaceCreateViewModel.kt
@@ -75,6 +75,10 @@ class PlaceCreateViewModel @Inject constructor(
                 removeImage(action.imageUri)
             }
 
+            is PlaceCreateAction.OnLastImageRemove -> {
+                _event.trySend(PlaceCreateEvent.NavigateToHome)
+            }
+
             is PlaceCreateAction.OnScrollPositionChange -> {
                 _uiState.update { it.copy(scrollPosition = action.position) }
             }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placecreate/component/SelectRow.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placecreate/component/SelectRow.kt
@@ -52,8 +52,12 @@ fun SelectRow(
     Card(
         onClick = onClick,
         modifier = modifier,
+        enabled = location == null,
         shape = MemoripTheme.shapes.roundedSmall,
-        colors = CardDefaults.cardColors(containerColor = MemoripTheme.colors.gray4),
+        colors = CardDefaults.cardColors(
+            containerColor = MemoripTheme.colors.gray4,
+            disabledContainerColor = MemoripTheme.colors.gray4
+        ),
         border = BorderStroke(
             width = MemoripLineWidth.Thin,
             brush = SolidColor(MemoripTheme.colors.gray2)
@@ -97,6 +101,7 @@ fun SelectRow(
             ) {
                 Text(
                     text = label,
+                    color = MemoripTheme.colors.onSurface,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                     style = MemoripTheme.typography.bodyLarge,

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placecreate/model/PlaceCreateAction.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placecreate/model/PlaceCreateAction.kt
@@ -21,6 +21,8 @@ sealed interface PlaceCreateAction {
 
     data class OnImagesRemove(val imageUri: Uri) : PlaceCreateAction
 
+    data object OnLastImageRemove : PlaceCreateAction
+
     data class OnScrollPositionChange(val position: Int) : PlaceCreateAction
 
     data class OnPlaceCreate(val context: Context) : PlaceCreateAction

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/selectimage/ImageCropScreen.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/selectimage/ImageCropScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toSize
 import androidx.core.graphics.withSave
+import androidx.core.net.toUri
 import com.andone.memorip.presentation.component.LoadingIndicatorScreen
 import com.andone.memorip.presentation.screen.selectimage.ImageCropScreenDimens.DRAW_RECT_ALPHA
 import com.andone.memorip.presentation.screen.selectimage.ImageCropScreenDimens.cropPadding
@@ -36,6 +37,7 @@ import com.andone.memorip.presentation.theme.MemoripIconSize
 import com.andone.memorip.presentation.theme.MemoripLineWidth
 import com.andone.memorip.presentation.theme.MemoripTheme
 import com.andone.memorip.presentation.util.BitmapCropUtil.detectEditorGestures
+import com.andone.memorip.presentation.util.DummyData
 import com.andone.memorip.presentation.util.toPx
 
 private object ImageCropScreenDimens {

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/selectimage/ImageCropScreen.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/selectimage/ImageCropScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toSize
 import androidx.core.graphics.withSave
+import com.andone.memorip.presentation.component.LoadingIndicatorScreen
 import com.andone.memorip.presentation.screen.selectimage.ImageCropScreenDimens.DRAW_RECT_ALPHA
 import com.andone.memorip.presentation.screen.selectimage.ImageCropScreenDimens.cropPadding
 import com.andone.memorip.presentation.screen.selectimage.ImageCropScreenDimens.touchTarget
@@ -64,32 +65,36 @@ fun ImageCropScreen(
     }
 
     Column(modifier = modifier.fillMaxSize()) {
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .weight(1f)
-                .clip(RectangleShape)
-                .onGloballyPositioned { state.updateViewSize(it.size.toSize()) }
-                .detectEditorGestures(
-                    key = state.currentUri.toString(),
-                    onDragStart = { offset ->
-                        state.dragStart(
-                            offset = offset,
-                            touchTarget = touchTarget.toPx(density)
-                        )
-                    },
-                    onDrag = state::drag,
-                    onZoom = { pan, zoom -> state.zoom(pan, zoom) },
-                    onDragEnd = state::dragEnd
+        if (state.isLoading) {
+            LoadingIndicatorScreen(modifier = Modifier.weight(1f))
+        } else {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f)
+                    .clip(RectangleShape)
+                    .onGloballyPositioned { state.updateViewSize(it.size.toSize()) }
+                    .detectEditorGestures(
+                        key = state.currentUri.toString(),
+                        onDragStart = { offset ->
+                            state.dragStart(
+                                offset = offset,
+                                touchTarget = touchTarget.toPx(density)
+                            )
+                        },
+                        onDrag = state::drag,
+                        onZoom = { pan, zoom -> state.zoom(pan, zoom) },
+                        onDragEnd = state::dragEnd
+                    )
+            ) {
+                ImageCropSection(
+                    imageBitmap = state.imageBitmap,
+                    viewSize = state.viewSize,
+                    offset = state.offset,
+                    scale = state.scale,
+                    cropRect = state.cropRect
                 )
-        ) {
-            ImageCropSection(
-                imageBitmap = state.imageBitmap,
-                viewSize = state.viewSize,
-                offset = state.offset,
-                scale = state.scale,
-                cropRect = state.cropRect
-            )
+            }
         }
 
         ImageCropBottomBar(

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/selectimage/ImageCropScreen.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/selectimage/ImageCropScreen.kt
@@ -26,18 +26,17 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toSize
 import androidx.core.graphics.withSave
-import androidx.core.net.toUri
 import com.andone.memorip.presentation.component.LoadingIndicatorScreen
 import com.andone.memorip.presentation.screen.selectimage.ImageCropScreenDimens.DRAW_RECT_ALPHA
 import com.andone.memorip.presentation.screen.selectimage.ImageCropScreenDimens.cropPadding
 import com.andone.memorip.presentation.screen.selectimage.ImageCropScreenDimens.touchTarget
 import com.andone.memorip.presentation.screen.selectimage.component.ImageCropBottomBar
 import com.andone.memorip.presentation.screen.selectimage.component.rememberCropImageState
+import com.andone.memorip.presentation.screen.selectimage.model.CropTransformData
 import com.andone.memorip.presentation.theme.MemoripIconSize
 import com.andone.memorip.presentation.theme.MemoripLineWidth
 import com.andone.memorip.presentation.theme.MemoripTheme
 import com.andone.memorip.presentation.util.BitmapCropUtil.detectEditorGestures
-import com.andone.memorip.presentation.util.DummyData
 import com.andone.memorip.presentation.util.toPx
 
 private object ImageCropScreenDimens {
@@ -49,7 +48,8 @@ private object ImageCropScreenDimens {
 @Composable
 fun ImageCropScreen(
     imageUris: List<Uri>,
-    onImagesCrop: (List<Uri>) -> Unit,
+    transformData: Map<Uri, CropTransformData>,
+    onImagesCrop: (List<Uri>, Map<Uri, CropTransformData>) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
@@ -57,6 +57,7 @@ fun ImageCropScreen(
 
     val state = rememberCropImageState(
         imageUris = imageUris,
+        transformData = transformData,
         context = context,
         onImagesCrop = onImagesCrop,
         cropPadding = cropPadding.toPx(density)
@@ -184,6 +185,7 @@ private fun ImageCropSection(
 private fun ImageCropScreenPreview() {
     ImageCropScreen(
         imageUris = emptyList(),
-        onImagesCrop = {}
+        transformData = emptyMap(),
+        onImagesCrop = { _, _ -> }
     )
 }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/selectimage/SelectImageScreen.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/selectimage/SelectImageScreen.kt
@@ -75,7 +75,8 @@ fun SelectImageScreenContent(
     if (uiState.selectedImages.isNotEmpty()) {
         ImageCropScreen(
             imageUris = uiState.selectedImages,
-            onImagesCrop = { uris -> onAction(SelectImageAction.OnImagesCrop(uris)) },
+            transformData = uiState.transformData,
+            onImagesCrop = { uris, data -> onAction(SelectImageAction.OnImagesCrop(uris, data)) },
             modifier = modifier
         )
     }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/selectimage/SelectImageScreen.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/selectimage/SelectImageScreen.kt
@@ -11,14 +11,17 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.andone.memorip.presentation.screen.selectimage.SelectImageScreenConstants.IMAGE_PICKER_MIN_COUNT
 import com.andone.memorip.presentation.screen.selectimage.SelectImageScreenConstants.MAX_PICTURE_COUNT
 import com.andone.memorip.presentation.screen.selectimage.model.SelectImageAction
 import com.andone.memorip.presentation.screen.selectimage.model.SelectImageEvent
 import com.andone.memorip.presentation.screen.selectimage.model.SelectImageUiState
 import com.andone.memorip.presentation.util.collectWithLifecycle
+import kotlin.math.max
 
 private object SelectImageScreenConstants {
     const val MAX_PICTURE_COUNT = 10
+    const val IMAGE_PICKER_MIN_COUNT = 2
 }
 
 @Composable
@@ -50,15 +53,16 @@ fun SelectImageScreenContent(
     onAction: (SelectImageAction) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val imagePickerLauncher =
-        rememberLauncherForActivityResult(contract = ActivityResultContracts.PickMultipleVisualMedia()) { uris ->
-            val imageCount = MAX_PICTURE_COUNT - uiState.selectedImages.size
-            if (uris.isNotEmpty()) {
-                onAction(SelectImageAction.OnImagesSelect(uris.take(imageCount)))
-            } else {
-                onAction(SelectImageAction.OnBack)
-            }
+    val imageCount = max(MAX_PICTURE_COUNT - uiState.selectedImages.size, IMAGE_PICKER_MIN_COUNT)
+    val imagePickerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.PickMultipleVisualMedia(maxItems = imageCount)
+    ) { uris ->
+        if (uris.isNotEmpty()) {
+            onAction(SelectImageAction.OnImagesSelect(uris.take(imageCount)))
+        } else {
+            onAction(SelectImageAction.OnBack)
         }
+    }
 
     LaunchedEffect(Unit) {
         if (uiState.selectedImages.isEmpty()) {
@@ -79,9 +83,6 @@ fun SelectImageScreenContent(
 
 @Preview(showBackground = true)
 @Composable
-fun SelectImageScreenPreview() {
-    SelectImageScreen(
-        onBack = {},
-        onImageSelect = {}
-    )
+private fun SelectImageScreenPreview() {
+    SelectImageScreen(onBack = {}, onImageSelect = {})
 }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/selectimage/SelectImageViewModel.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/selectimage/SelectImageViewModel.kt
@@ -2,6 +2,7 @@ package com.andone.memorip.presentation.screen.selectimage
 
 import android.net.Uri
 import androidx.lifecycle.ViewModel
+import com.andone.memorip.presentation.screen.selectimage.model.CropTransformData
 import com.andone.memorip.presentation.screen.selectimage.model.SelectImageAction
 import com.andone.memorip.presentation.screen.selectimage.model.SelectImageEvent
 import com.andone.memorip.presentation.screen.selectimage.model.SelectImageUiState
@@ -30,7 +31,7 @@ class SelectImageViewModel @Inject constructor() : ViewModel() {
             }
 
             is SelectImageAction.OnImagesCrop -> {
-                addImages(action.images)
+                addImages(action.images, action.transformData)
             }
 
             SelectImageAction.OnBack -> {
@@ -43,8 +44,8 @@ class SelectImageViewModel @Inject constructor() : ViewModel() {
         _uiState.update { it.copy(selectedImages = images) }
     }
 
-    private fun addImages(images: List<Uri>) {
-        _uiState.update { it.copy(croppedImages = images) }
+    private fun addImages(images: List<Uri>, transformData: Map<Uri, CropTransformData>) {
+        _uiState.update { it.copy(croppedImages = images, transformData = transformData) }
         _event.trySend(SelectImageEvent.NavigateToSelectLocation(images))
     }
 }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/selectimage/component/ImageCropBottomBar.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/selectimage/component/ImageCropBottomBar.kt
@@ -19,10 +19,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.core.net.toUri
 import com.andone.memorip.presentation.R
 import com.andone.memorip.presentation.theme.MemoripPadding
 import com.andone.memorip.presentation.theme.MemoripSpace
 import com.andone.memorip.presentation.theme.MemoripTheme
+import com.andone.memorip.presentation.util.DummyData
 
 @Composable
 fun ImageCropBottomBar(
@@ -85,14 +87,12 @@ fun ImageCropBottomBar(
                 )
             )
 
-            val iconRes =
-                if (imageUris.size == croppedImageKeys.size) R.drawable.ic_arrow_forward else R.drawable.ic_check
             IconButton(
                 onClick = onImageCrop,
                 colors = IconButtonDefaults.iconButtonColors(containerColor = MemoripTheme.colors.primary)
             ) {
                 Icon(
-                    painter = painterResource(iconRes),
+                    painter = painterResource(R.drawable.ic_check),
                     contentDescription = stringResource(R.string.select_image_done),
                     tint = MemoripTheme.colors.white
                 )
@@ -105,7 +105,7 @@ fun ImageCropBottomBar(
 @Composable
 private fun ImageCropBottomBarPreview() {
     ImageCropBottomBar(
-        imageUris = emptyList(),
+        imageUris = DummyData.placeImages.map { it.url.toUri() },
         croppedImageKeys = emptySet(),
         currentIndex = 0,
         onDismiss = {},

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/selectimage/component/ImageCropStateHolder.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/selectimage/component/ImageCropStateHolder.kt
@@ -366,22 +366,18 @@ class CropImageState(
             val bitmap = imageBitmap
             val uri = currentUri
             if (bitmap != null && uri != null) {
-                if (croppedImages.size == imageUris.size) {
-                    val finalResult = imageUris.mapNotNull { croppedImages[it] }
-                    if (finalResult.size == imageUris.size) {
-                        onImagesCrop(finalResult)
-                    }
-                } else {
-                    val resultUri = BitmapCropUtil.cropImage(
-                        context = context,
-                        bitmap = bitmap,
-                        viewSize = viewSize,
-                        offset = offset,
-                        scale = scale,
-                        cropRect = cropRect
-                    )
-                    croppedImages[uri] = resultUri
+                croppedImages[uri] = BitmapCropUtil.cropImage(
+                    context = context,
+                    bitmap = bitmap,
+                    viewSize = viewSize,
+                    offset = offset,
+                    scale = scale,
+                    cropRect = cropRect
+                )
 
+                if (croppedImages.size == imageUris.size) {
+                    onImagesCrop(imageUris.mapNotNull { croppedImages[it] })
+                } else {
                     val nextIndex = imageUris.indexOfFirst { !croppedImages.containsKey(it) }
                     if (nextIndex != -1) {
                         currentIndex = nextIndex

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/selectimage/component/ImageCropStateHolder.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/selectimage/component/ImageCropStateHolder.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
 import com.andone.memorip.presentation.screen.selectimage.component.ImageCropStateHolderConstants.MAX_RATIO
 import com.andone.memorip.presentation.screen.selectimage.component.ImageCropStateHolderConstants.MIN_SIZE
+import com.andone.memorip.presentation.screen.selectimage.model.CropTransformData
 import com.andone.memorip.presentation.util.BitmapCropUtil
 import com.andone.memorip.presentation.util.BitmapCropUtil.bitmapToScreenRect
 import com.andone.memorip.presentation.util.BitmapCropUtil.calculateOffset
@@ -43,23 +44,25 @@ enum class DragHandle {
 @Composable
 fun rememberCropImageState(
     imageUris: List<Uri>,
+    transformData: Map<Uri, CropTransformData>,
     context: Context,
     cropPadding: Float,
-    onImagesCrop: (List<Uri>) -> Unit,
+    onImagesCrop: (List<Uri>, Map<Uri, CropTransformData>) -> Unit,
     scope: CoroutineScope = rememberCoroutineScope()
 ): CropImageState {
-    return remember(imageUris, context, cropPadding, scope, onImagesCrop) {
-        CropImageState(imageUris, context, cropPadding, scope, onImagesCrop)
+    return remember(imageUris, transformData, context, cropPadding, scope, onImagesCrop) {
+        CropImageState(imageUris, transformData, context, cropPadding, scope, onImagesCrop)
     }
 }
 
 @Stable
 class CropImageState(
     private val imageUris: List<Uri>,
+    private val transformData: Map<Uri, CropTransformData>,
     private val context: Context,
     private val cropPadding: Float,
     private val scope: CoroutineScope,
-    private val onImagesCrop: (List<Uri>) -> Unit
+    private val onImagesCrop: (List<Uri>, Map<Uri, CropTransformData>) -> Unit
 ) {
     var currentIndex by mutableIntStateOf(0)
         private set
@@ -84,6 +87,9 @@ class CropImageState(
 
     val croppedImages = mutableStateMapOf<Uri, Uri>()
 
+    private val transformDataMap =
+        mutableStateMapOf<Uri, CropTransformData>().apply { putAll(transformData) }
+
     var isLoading by mutableStateOf(false)
         private set
 
@@ -99,19 +105,44 @@ class CropImageState(
         )
 
     fun updateViewSize(size: Size) {
-        viewSize = size
-        resetTransformation()
+        if (viewSize != size) {
+            viewSize = size
+            if (cropRect == Rect.Zero) {
+                resetTransformation()
+            }
+        }
     }
 
     fun selectImage(index: Int) {
+        saveState()
         currentIndex = index
+    }
+
+    private fun saveState() {
+        currentUri?.let { uri ->
+            if (imageBitmap != null && cropRect != Rect.Zero) {
+                transformDataMap[uri] = CropTransformData(
+                    scale = scale,
+                    offset = offset,
+                    cropRect = cropRect
+                )
+            }
+        }
     }
 
     suspend fun loadImage() {
         isLoading = true
         currentUri?.let { uri ->
             imageBitmap = loadBitmapFromUri(context = context, uri = uri)
-            resetTransformation()
+
+            val savedData = transformDataMap[uri]
+            if (savedData != null) {
+                scale = savedData.scale
+                offset = savedData.offset
+                cropRect = savedData.cropRect
+            } else {
+                resetTransformation()
+            }
         }
         isLoading = false
     }
@@ -367,6 +398,8 @@ class CropImageState(
     }
 
     fun cropImage() {
+        saveState()
+
         scope.launch {
             val bitmap = imageBitmap
             val uri = currentUri
@@ -381,11 +414,11 @@ class CropImageState(
                 )
 
                 if (croppedImages.size == imageUris.size) {
-                    onImagesCrop(imageUris.mapNotNull { croppedImages[it] })
+                    onImagesCrop(imageUris.mapNotNull { croppedImages[it] }, transformDataMap)
                 } else {
                     val nextIndex = imageUris.indexOfFirst { !croppedImages.containsKey(it) }
                     if (nextIndex != -1) {
-                        currentIndex = nextIndex
+                        selectImage(nextIndex)
                     }
                 }
             }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/selectimage/component/ImageCropStateHolder.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/selectimage/component/ImageCropStateHolder.kt
@@ -84,6 +84,9 @@ class CropImageState(
 
     val croppedImages = mutableStateMapOf<Uri, Uri>()
 
+    var isLoading by mutableStateOf(false)
+        private set
+
     private var currentDragHandle by mutableStateOf(DragHandle.None)
 
     private val viewCenter: Offset
@@ -105,10 +108,12 @@ class CropImageState(
     }
 
     suspend fun loadImage() {
+        isLoading = true
         currentUri?.let { uri ->
             imageBitmap = loadBitmapFromUri(context = context, uri = uri)
             resetTransformation()
         }
+        isLoading = false
     }
 
     private fun resetTransformation() {

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/selectimage/component/ThumbnailItem.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/selectimage/component/ThumbnailItem.kt
@@ -19,6 +19,7 @@ import androidx.core.net.toUri
 import coil.compose.AsyncImage
 import com.andone.memorip.presentation.R
 import com.andone.memorip.presentation.screen.selectimage.component.ThumbnailItemDimens.imageSize
+import com.andone.memorip.presentation.theme.MemoripAlpha
 import com.andone.memorip.presentation.theme.MemoripLineWidth
 import com.andone.memorip.presentation.theme.MemoripTheme
 
@@ -56,7 +57,7 @@ fun ThumbnailItem(
             Box(
                 modifier = Modifier
                     .fillMaxSize()
-                    .background(MemoripTheme.colors.gray),
+                    .background(MemoripTheme.colors.lightGray.copy(alpha = MemoripAlpha.IMAGE_OVERLAY)),
                 contentAlignment = Alignment.Center
             ) {
                 Icon(

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/selectimage/model/CropTransformData.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/selectimage/model/CropTransformData.kt
@@ -1,0 +1,10 @@
+package com.andone.memorip.presentation.screen.selectimage.model
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+
+data class CropTransformData(
+    val scale: Float,
+    val offset: Offset,
+    val cropRect: Rect
+)

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/selectimage/model/SelectImageAction.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/selectimage/model/SelectImageAction.kt
@@ -6,7 +6,10 @@ sealed interface SelectImageAction {
 
     data class OnImagesSelect(val images: List<Uri>) : SelectImageAction
 
-    data class OnImagesCrop(val images: List<Uri>) : SelectImageAction
+    data class OnImagesCrop(
+        val images: List<Uri>,
+        val transformData: Map<Uri, CropTransformData>
+    ) : SelectImageAction
 
     data object OnBack : SelectImageAction
 }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/selectimage/model/SelectImageUiState.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/selectimage/model/SelectImageUiState.kt
@@ -4,5 +4,6 @@ import android.net.Uri
 
 data class SelectImageUiState(
     val selectedImages: List<Uri> = emptyList(),
-    val croppedImages: List<Uri> = emptyList()
+    val croppedImages: List<Uri> = emptyList(),
+    val transformData: Map<Uri, CropTransformData> = emptyMap()
 )

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/selectlocation/SelectLocationScreen.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/selectlocation/SelectLocationScreen.kt
@@ -130,34 +130,35 @@ private fun SelectLocationContent(
         ),
         windowInsets = WindowInsets()
     ) {
-        MemoripPagingList(
-            pagingItems = locations,
-            itemKey = { it.id },
-            modifier = Modifier.fillMaxSize(),
-            initialContent = {
-                EmptyText(
-                    text = stringResource(R.string.search_bar_placeholder),
-                    modifier = Modifier.fillMaxSize()
-                )
-            },
-            emptyContent = {
-                EmptyText(
-                    text = stringResource(R.string.search_bar_empty_result),
-                    modifier = Modifier.fillMaxSize()
-                )
-            },
-            itemContent = { location ->
-                LocationItem(
-                    location = location,
-                    onClick = {
-                        onAction(SelectLocationAction.OnLocationClick(location))
-                        cameraPositionMove(LatLng(location.latitude, location.longitude))
-                        searchBarExpanded = false
-                    },
-                    modifier = Modifier.fillMaxWidth()
-                )
-            }
-        )
+        if (uiState.query.isEmpty()) {
+            EmptyText(
+                text = stringResource(R.string.search_bar_placeholder),
+                modifier = Modifier.fillMaxSize()
+            )
+        } else {
+            MemoripPagingList(
+                pagingItems = locations,
+                itemKey = { it.id },
+                modifier = Modifier.fillMaxSize(),
+                emptyContent = {
+                    EmptyText(
+                        text = stringResource(R.string.search_bar_empty_result),
+                        modifier = Modifier.fillMaxSize()
+                    )
+                },
+                itemContent = { location ->
+                    LocationItem(
+                        location = location,
+                        onClick = {
+                            onAction(SelectLocationAction.OnLocationClick(location))
+                            cameraPositionMove(LatLng(location.latitude, location.longitude))
+                            searchBarExpanded = false
+                        },
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
+            )
+        }
     }
 
     Box(modifier = Modifier.fillMaxSize()) {

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/theme/Dimen.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/theme/Dimen.kt
@@ -33,6 +33,7 @@ object MemoripIconSize {
 }
 
 object MemoripHeight {
+    val bottomBar = 60.dp
     val TextBoxHigh = 120.dp
     val SearchBoxHeight = 36.dp
 }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/theme/Dimen.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/theme/Dimen.kt
@@ -78,7 +78,7 @@ object MemoripAlpha {
 
     /* ---------- Image ---------- */
     const val IMAGE_PLACEHOLDER = 0.3f
-    const val IMAGE_OVERLAY = 0.68f
+    const val IMAGE_OVERLAY = 0.5f
 
 
     /* ---------- Divider / Border ---------- */

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/util/BitmapCropUtil.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/util/BitmapCropUtil.kt
@@ -5,6 +5,7 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.Canvas
 import android.graphics.Color
+import android.graphics.Matrix
 import android.graphics.Paint
 import android.net.Uri
 import androidx.compose.foundation.gestures.awaitEachGesture
@@ -18,6 +19,7 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.positionChanged
 import androidx.core.graphics.createBitmap
+import androidx.exifinterface.media.ExifInterface
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
@@ -30,8 +32,29 @@ object BitmapCropUtil {
     suspend fun loadBitmapFromUri(context: Context, uri: Uri): Bitmap? {
         return withContext(Dispatchers.IO) {
             runCatching {
-                context.contentResolver.openInputStream(uri)?.use { stream ->
+                // EXIF 데이터 - 회전 각도 확인
+                val rotation = context.contentResolver.openInputStream(uri)?.use { stream ->
+                    val orientation = ExifInterface(stream).getAttributeInt(
+                        ExifInterface.TAG_ORIENTATION,
+                        ExifInterface.ORIENTATION_NORMAL
+                    )
+                    when (orientation) {
+                        ExifInterface.ORIENTATION_ROTATE_90 -> 90f
+                        ExifInterface.ORIENTATION_ROTATE_180 -> 180f
+                        ExifInterface.ORIENTATION_ROTATE_270 -> 270f
+                        else -> 0f
+                    }
+                } ?: return@runCatching null
+
+                val bitmap = context.contentResolver.openInputStream(uri)?.use { stream ->
                     BitmapFactory.decodeStream(stream)
+                } ?: return@runCatching null
+
+                if (rotation != 0f) {
+                    val matrix = Matrix().apply { postRotate(rotation) }
+                    Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, matrix, true)
+                } else {
+                    bitmap
                 }
             }.getOrNull()
         }


### PR DESCRIPTION
## 📝 변경 사항
이미지 크롭 기능 개선, 바텀바 UI 리팩토링, 장소 추가 화면 UX 개선 등 다양한 사용성 및 디자인 개선 작업을 진행했습니다.

## 🎯 작업 내용

### 이미지 크롭 기능 개선
- **EXIF 정보 기반 회전 처리**
  - ExifInterface 라이브러리 추가 (androidx.exifinterface:1.3.6)
  - 이미지 로드 시 EXIF Orientation 정보 읽어서 자동 회전
  - 90°, 180°, 270° 회전 각도 자동 처리
  - 카메라로 촬영한 세로 이미지가 자동으로 올바르게 표시됨

- **크롭 상태 저장 및 복원**
  - CropTransformData 모델 추가 (scale, offset, cropRect 저장)
  - 이미지 전환 시 크롭 상태 자동 저장
  - 이전에 크롭했던 이미지로 돌아갈 때 상태 복원
  - transformData를 Map으로 관리하여 모든 이미지의 크롭 정보 유지

- **크롭 UI/UX 개선**
  - 크롭 완료 버튼 아이콘 통일 (check 아이콘으로 고정)
  - 이미지 로딩 중 LoadingIndicator 표시
  - 썸네일 오버레이 투명도 조정 (0.68 → 0.5)
  - 이미지 선택 시 자동으로 다음 미크롭 이미지로 이동

- **이미지 피커 개선**
  - PickMultipleVisualMedia에 maxItems 파라미터 명시
  - 최소 2장 선택 보장 (IMAGE_PICKER_MIN_COUNT)
  - 남은 슬롯 계산 로직 개선

### MainBottomBar 리팩토링
- **NavigationBar → Custom Row 구조 변경**
  - Material3 NavigationBar 제거
  - Row + IconButton으로 커스텀 구현
  - 불필요한 indicator 및 label 제거로 심플한 디자인

- **네비게이션 바 높이 고정**
  - WindowInsets.navigationBars를 활용한 정확한 패딩 계산
  - MemoripHeight.bottomBar (60dp) 상수 추가
  - 시스템 네비게이션 바와의 겹침 방지

- **레이아웃 개선**
  - SpaceAround를 사용한 균등 배치
  - FAB 공간 확보를 위한 Spacer 최적화
  - 선택된 탭의 Primary 색상 표시

### 장소 추가 화면 개선
- **마지막 이미지 삭제 시 자동 네비게이션**
  - OnLastImageRemove Action 추가
  - 모든 이미지 삭제 시 자동으로 홈으로 이동
  - LaunchedEffect로 이미지 리스트 모니터링

- **SelectRow 비활성화 상태 추가**
  - 위치가 선택된 경우 Card 비활성화
  - disabledContainerColor 설정으로 일관된 디자인 유지
  - label 색상을 onSurface로 명시하여 가독성 보장

- **함수 파라미터명 개선**
  - onImageCreate → onNavigateToHome (의미 명확화)

### 위치 선택 화면 개선
- **MemoripPagingList 구조 개선**
  - initialContent 파라미터 제거
  - emptyContent를 필수 파라미터로 변경
  - 파라미터 순서 최적화 (emptyContent를 앞으로)

- **검색 상태별 UI 분리**
  - 검색어 없을 때: placeholder 메시지 표시
  - 검색어 있을 때: PagingList 표시
  - 검색 결과 없을 때: 빈 결과 메시지 표시
  - 조건문으로 명확한 상태 분기

### 디자인 시스템 업데이트
- **Alpha 값 조정**
  - IMAGE_OVERLAY: 0.68 → 0.5 (더 밝은 오버레이)
  - 썸네일 체크 아이콘 배경 투명도 개선

- **Dimen 추가**
  - MemoripHeight.bottomBar: 60dp (바텀바 고정 높이)

### 코드 품질 개선
- **Preview 함수 private 처리**
  - 외부 노출 불필요한 Preview 함수들 private으로 변경
  - API surface 최소화

- **import 정리**
  - 사용하지 않는 import 제거
  - 파일별 import 순서 정리

## 🔗 관련 이슈
Closes #138

## 📸 스크린샷
https://github.com/user-attachments/assets/29a76ff8-9ee0-4ae5-af35-c5a627d3fe30

## 💬 리뷰어에게
- EXIF 회전 처리가 다양한 기기/카메라에서 잘 동작하는지 테스트 부탁드립니다.
- 이미지 크롭 상태 저장/복원이 여러 이미지 편집 시나리오에서 안정적으로 동작하는지 확인해주세요.
- MainBottomBar의 네비게이션 영역 높이가 다양한 기기에서 적절한지 검토 부탁드립니다.
- 마지막 이미지 삭제 시 자동 네비게이션 동작이 직관적인지 의견 부탁드립니다.