### PR TITLE
[Feature] 홈화면 필터링 기능 구현

### DIFF
--- a/client/data/src/main/java/com/andone/memorip/data/di/DataSourceModule.kt
+++ b/client/data/src/main/java/com/andone/memorip/data/di/DataSourceModule.kt
@@ -4,6 +4,8 @@ import com.andone.memorip.data.group.datasource.remote.GroupRemoteDataSource
 import com.andone.memorip.data.group.datasource.remote.GroupRemoteDataSourceImpl
 import com.andone.memorip.data.place.datasource.remote.PlaceRemoteDataSource
 import com.andone.memorip.data.place.datasource.remote.PlaceRemoteDataSourceImpl
+import com.andone.memorip.data.tag.datasource.remote.TagRemoteDataSource
+import com.andone.memorip.data.tag.datasource.remote.TagRemoteDataSourceImpl
 import com.andone.memorip.data.user.datasource.remote.UserRemoteDataSource
 import com.andone.memorip.data.user.datasource.remote.UserRemoteDataSourceImpl
 import dagger.Binds
@@ -27,4 +29,8 @@ abstract class DataSourceModule {
     @Binds
     @Singleton
     abstract fun bindGroupDataSource(impl: GroupRemoteDataSourceImpl): GroupRemoteDataSource
+
+    @Binds
+    @Singleton
+    abstract fun bindTagDataSource(impl: TagRemoteDataSourceImpl): TagRemoteDataSource
 }

--- a/client/data/src/main/java/com/andone/memorip/data/di/RepositoryModule.kt
+++ b/client/data/src/main/java/com/andone/memorip/data/di/RepositoryModule.kt
@@ -7,12 +7,14 @@ import com.andone.memorip.data.place.repositoryimpl.PlaceRepositoryImpl
 import com.andone.memorip.domain.repository.GroupRepository
 import com.andone.memorip.data.auth.repositoryimpl.FirebaseAuthRepositoryImpl
 import com.andone.memorip.data.auth.repositoryimpl.FirebaseTokenRepositoryImpl
+import com.andone.memorip.data.tag.repositoryimpl.TagRepositoryImpl
 import com.andone.memorip.data.user.repositoryimpl.UserRepositoryImpl
 import com.andone.memorip.domain.auth.TokenProvider
 import com.andone.memorip.domain.auth.TokenRefresher
 import com.andone.memorip.domain.repository.AuthRepository
 import com.andone.memorip.domain.repository.KakaoSearchRepository
 import com.andone.memorip.domain.repository.PlaceRepository
+import com.andone.memorip.domain.repository.TagRepository
 import com.andone.memorip.domain.repository.UserRepository
 import dagger.Binds
 import dagger.Module
@@ -49,4 +51,7 @@ abstract class RepositoryModule {
 
     @Binds
     abstract fun TokenRefresher(impl: FirebaseTokenRepositoryImpl): TokenRefresher
+
+    @Binds
+    abstract fun TagRepository(impl: TagRepositoryImpl): TagRepository
 }

--- a/client/data/src/main/java/com/andone/memorip/data/di/RepositoryModule.kt
+++ b/client/data/src/main/java/com/andone/memorip/data/di/RepositoryModule.kt
@@ -3,7 +3,6 @@ package com.andone.memorip.data.di
 import com.andone.memorip.data.group.repositoryimpl.GroupRepositoryImpl
 import com.andone.memorip.data.kakaosearch.repositoryimpl.KakaoSearchRepositoryImpl
 import com.andone.memorip.data.place.repositoryimpl.PlaceRepositoryImpl
-
 import com.andone.memorip.domain.repository.GroupRepository
 import com.andone.memorip.data.auth.repositoryimpl.FirebaseAuthRepositoryImpl
 import com.andone.memorip.data.auth.repositoryimpl.FirebaseTokenRepositoryImpl
@@ -47,11 +46,12 @@ abstract class RepositoryModule {
     abstract fun bindUserRepository(impl: UserRepositoryImpl): UserRepository
 
     @Binds
+    @Singleton
+    abstract fun bindTagRepository(impl: TagRepositoryImpl): TagRepository
+
+    @Binds
     abstract fun bindTokenProvider(impl: FirebaseTokenRepositoryImpl): TokenProvider
 
     @Binds
-    abstract fun TokenRefresher(impl: FirebaseTokenRepositoryImpl): TokenRefresher
-
-    @Binds
-    abstract fun TagRepository(impl: TagRepositoryImpl): TagRepository
+    abstract fun bingTokenRefresher(impl: FirebaseTokenRepositoryImpl): TokenRefresher
 }

--- a/client/data/src/main/java/com/andone/memorip/data/di/ServerNetworkModule.kt
+++ b/client/data/src/main/java/com/andone/memorip/data/di/ServerNetworkModule.kt
@@ -4,6 +4,7 @@ import com.andone.memorip.data.BuildConfig
 import com.andone.memorip.data.auth.AuthInterceptor
 import com.andone.memorip.data.group.datasource.GroupService
 import com.andone.memorip.data.place.datasource.PlaceService
+import com.andone.memorip.data.tag.datasource.TagService
 import com.andone.memorip.data.user.datasource.UserService
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import dagger.Module
@@ -77,5 +78,11 @@ object ServerNetworkModule {
     @Singleton
     fun provideGroupService(@ServerRetrofit retrofit: Retrofit): GroupService {
         return retrofit.create(GroupService::class.java)
+    }
+
+    @Provides
+    @Singleton
+    fun provideTagService(@ServerRetrofit retrofit: Retrofit): TagService {
+        return retrofit.create(TagService::class.java)
     }
 }

--- a/client/data/src/main/java/com/andone/memorip/data/place/datasource/PlaceListPagingSource.kt
+++ b/client/data/src/main/java/com/andone/memorip/data/place/datasource/PlaceListPagingSource.kt
@@ -12,7 +12,7 @@ class PlaceListPagingSource(
     private val pageSize: Int,
     private val sort: List<String>? = null,
     private val query: String? = null,
-    private val tagIds: List<UUID>? = null,
+    private val tagIds: List<String>? = null,
     private val region1Depth: String? = null,
     private val region2Depth: List<String>? = null
 ) : PagingSource<Int, PlaceListItem>() {

--- a/client/data/src/main/java/com/andone/memorip/data/place/datasource/PlaceListPagingSource.kt
+++ b/client/data/src/main/java/com/andone/memorip/data/place/datasource/PlaceListPagingSource.kt
@@ -24,7 +24,11 @@ class PlaceListPagingSource(
             val response = service.getPlaces(
                 page = page,
                 size = pageSize,
-                sort = sort
+                sort = sort,
+                query = query,
+                tagIds = tagIds,
+                region1Depth = region1Depth,
+                region2Depth = region2Depth
             )
 
             if (response.error != null) {

--- a/client/data/src/main/java/com/andone/memorip/data/place/datasource/PlaceListPagingSource.kt
+++ b/client/data/src/main/java/com/andone/memorip/data/place/datasource/PlaceListPagingSource.kt
@@ -5,11 +5,16 @@ import com.andone.memorip.domain.model.PlaceListItem
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
 import com.andone.memorip.data.place.model.toDomain
+import java.util.UUID
 
 class PlaceListPagingSource(
     private val service: PlaceService,
     private val pageSize: Int,
-    private val sort: List<String>? = null
+    private val sort: List<String>? = null,
+    private val query: String? = null,
+    private val tagIds: List<UUID>? = null,
+    private val region1Depth: String? = null,
+    private val region2Depth: List<String>? = null
 ) : PagingSource<Int, PlaceListItem>() {
 
     override suspend fun load(params: LoadParams<Int>): LoadResult<Int, PlaceListItem> {

--- a/client/data/src/main/java/com/andone/memorip/data/place/datasource/PlaceService.kt
+++ b/client/data/src/main/java/com/andone/memorip/data/place/datasource/PlaceService.kt
@@ -23,7 +23,7 @@ interface PlaceService {
     @GET("/api/places")
     suspend fun getPlaces(
         @Query("query") query: String? = null,
-        @Query("tagIds") tagIds: List<UUID>? = null,
+        @Query("tagIds") tagIds: List<String>? = null,
         @Query("region1Depth") region1Depth: String? = null,
         @Query("region2Depth") region2Depth: List<String>? = null,
         @Query("page") page: Int,

--- a/client/data/src/main/java/com/andone/memorip/data/place/datasource/PlaceService.kt
+++ b/client/data/src/main/java/com/andone/memorip/data/place/datasource/PlaceService.kt
@@ -16,11 +16,16 @@ import retrofit2.http.POST
 import retrofit2.http.Part
 import retrofit2.http.Path
 import retrofit2.http.Query
+import java.util.UUID
 
 interface PlaceService {
 
     @GET("/api/places")
     suspend fun getPlaces(
+        @Query("query") query: String? = null,
+        @Query("tagIds") tagIds: List<UUID>? = null,
+        @Query("region1Depth") region1Depth: String? = null,
+        @Query("region2Depth") region2Depth: List<String>? = null,
         @Query("page") page: Int,
         @Query("size") size: Int,
         @Query("sort") sort: List<String>? = null

--- a/client/data/src/main/java/com/andone/memorip/data/place/datasource/remote/PlaceRemoteDataSource.kt
+++ b/client/data/src/main/java/com/andone/memorip/data/place/datasource/remote/PlaceRemoteDataSource.kt
@@ -9,10 +9,18 @@ import com.andone.memorip.domain.model.response.PlaceDetailResponse
 import com.andone.memorip.domain.model.response.PlaceImageUploadResponse
 import kotlinx.coroutines.flow.Flow
 import java.io.File
+import java.util.UUID
 
 interface PlaceRemoteDataSource {
     suspend fun getPlaceDetail(placeId: String): Result<PlaceDetailResponse>
-    fun getPlaceList(): Flow<PagingData<PlaceListItem>>
+    fun getPlaceList(
+        query: String? = null,
+        tagIds: List<UUID>? = null,
+        region1Depth: String? = null,
+        region2Depth: List<String>? = null,
+        sort: List<String>? = null
+    ): Flow<PagingData<PlaceListItem>>
+
     suspend fun uploadImage(file: File): Result<PlaceImageUploadResponse>
     suspend fun createPlace(place: PlaceCreateRequest): Result<PlaceCreateResponse>
     suspend fun updatePlaceGroups(
@@ -20,5 +28,6 @@ interface PlaceRemoteDataSource {
         addGroupIds: List<String>,
         removeGroupIds: List<String>
     ): Result<Unit>
+
     fun loadRegions(): List<Region>
 }

--- a/client/data/src/main/java/com/andone/memorip/data/place/datasource/remote/PlaceRemoteDataSource.kt
+++ b/client/data/src/main/java/com/andone/memorip/data/place/datasource/remote/PlaceRemoteDataSource.kt
@@ -15,7 +15,7 @@ interface PlaceRemoteDataSource {
     suspend fun getPlaceDetail(placeId: String): Result<PlaceDetailResponse>
     fun getPlaceList(
         query: String? = null,
-        tagIds: List<UUID>? = null,
+        tagIds: List<String>? = null,
         region1Depth: String? = null,
         region2Depth: List<String>? = null,
         sort: List<String>? = null

--- a/client/data/src/main/java/com/andone/memorip/data/place/datasource/remote/PlaceRemoteDataSourceImpl.kt
+++ b/client/data/src/main/java/com/andone/memorip/data/place/datasource/remote/PlaceRemoteDataSourceImpl.kt
@@ -42,7 +42,7 @@ class PlaceRemoteDataSourceImpl @Inject constructor(
 
     override fun getPlaceList(
         query: String?,
-        tagIds: List<UUID>?,
+        tagIds: List<String>?,
         region1Depth: String?,
         region2Depth: List<String>?,
         sort: List<String>?

--- a/client/data/src/main/java/com/andone/memorip/data/place/datasource/remote/PlaceRemoteDataSourceImpl.kt
+++ b/client/data/src/main/java/com/andone/memorip/data/place/datasource/remote/PlaceRemoteDataSourceImpl.kt
@@ -25,6 +25,7 @@ import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.MultipartBody
 import okhttp3.RequestBody.Companion.asRequestBody
 import java.io.File
+import java.util.UUID
 import javax.inject.Inject
 import kotlin.collections.component1
 import kotlin.collections.component2
@@ -39,7 +40,13 @@ class PlaceRemoteDataSourceImpl @Inject constructor(
         return apiCall { placeService.getPlaceDetail(placeId = placeId) }
     }
 
-    override fun getPlaceList(): Flow<PagingData<PlaceListItem>> =
+    override fun getPlaceList(
+        query: String?,
+        tagIds: List<UUID>?,
+        region1Depth: String?,
+        region2Depth: List<String>?,
+        sort: List<String>?
+    ): Flow<PagingData<PlaceListItem>> =
         Pager(
             config = PagingConfig(
                 pageSize = DEFAULT_PAGE_SIZE,
@@ -49,7 +56,12 @@ class PlaceRemoteDataSourceImpl @Inject constructor(
             pagingSourceFactory = {
                 PlaceListPagingSource(
                     service = placeService,
-                    pageSize = DEFAULT_PAGE_SIZE
+                    pageSize = DEFAULT_PAGE_SIZE,
+                    sort = sort,
+                    query = query,
+                    tagIds = tagIds,
+                    region1Depth = region1Depth,
+                    region2Depth = region2Depth
                 )
             }
         ).flow

--- a/client/data/src/main/java/com/andone/memorip/data/place/repositoryimpl/PlaceRepositoryImpl.kt
+++ b/client/data/src/main/java/com/andone/memorip/data/place/repositoryimpl/PlaceRepositoryImpl.kt
@@ -11,6 +11,7 @@ import com.andone.memorip.domain.model.response.PlaceImageUploadResponse
 import com.andone.memorip.domain.repository.PlaceRepository
 import kotlinx.coroutines.flow.Flow
 import java.io.File
+import java.util.UUID
 import javax.inject.Inject
 
 class PlaceRepositoryImpl @Inject constructor(
@@ -20,8 +21,20 @@ class PlaceRepositoryImpl @Inject constructor(
         return placeRemoteDataSource.getPlaceDetail(placeId = placeId)
     }
 
-    override fun getPlaceList(): Flow<PagingData<PlaceListItem>> {
-        return placeRemoteDataSource.getPlaceList()
+    override fun getPlaceList(
+        query: String?,
+        tagIds: List<UUID>?,
+        region1Depth: String?,
+        region2Depth: List<String>?,
+        sort: List<String>?
+    ): Flow<PagingData<PlaceListItem>> {
+        return placeRemoteDataSource.getPlaceList(
+            query = query,
+            tagIds = tagIds,
+            region1Depth = region1Depth,
+            region2Depth = region2Depth,
+            sort = sort
+        )
     }
 
     override suspend fun uploadImage(file: File): Result<PlaceImageUploadResponse> {

--- a/client/data/src/main/java/com/andone/memorip/data/place/repositoryimpl/PlaceRepositoryImpl.kt
+++ b/client/data/src/main/java/com/andone/memorip/data/place/repositoryimpl/PlaceRepositoryImpl.kt
@@ -23,7 +23,7 @@ class PlaceRepositoryImpl @Inject constructor(
 
     override fun getPlaceList(
         query: String?,
-        tagIds: List<UUID>?,
+        tagIds: List<String>?,
         region1Depth: String?,
         region2Depth: List<String>?,
         sort: List<String>?

--- a/client/data/src/main/java/com/andone/memorip/data/tag/datasource/TagListPagingSource.kt
+++ b/client/data/src/main/java/com/andone/memorip/data/tag/datasource/TagListPagingSource.kt
@@ -1,25 +1,23 @@
-package com.andone.memorip.data.place.datasource
+package com.andone.memorip.data.tag.datasource
 
 import android.util.Log
-import com.andone.memorip.domain.model.PlaceListItem
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
-import com.andone.memorip.data.place.model.toDomain
+import com.andone.memorip.domain.model.Tag
+import com.andone.memorip.data.tag.model.toDomain
 
-class PlaceListPagingSource(
-    private val service: PlaceService,
+class TagListPagingSource(
+    private val service: TagService,
     private val pageSize: Int,
-    private val sort: List<String>? = null
-) : PagingSource<Int, PlaceListItem>() {
+) : PagingSource<Int, Tag>() {
 
-    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, PlaceListItem> {
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, Tag> {
         val page = params.key ?: 0
 
         return try {
-            val response = service.getPlaces(
+            val response = service.getTags(
                 page = page,
-                size = pageSize,
-                sort = sort
+                size = pageSize
             )
 
             if (response.error != null) {
@@ -41,7 +39,7 @@ class PlaceListPagingSource(
         }
     }
 
-    override fun getRefreshKey(state: PagingState<Int, PlaceListItem>): Int? {
+    override fun getRefreshKey(state: PagingState<Int, Tag>): Int? {
         return state.anchorPosition?.let { anchor ->
             state.closestPageToPosition(anchor)?.prevKey?.plus(1)
                 ?: state.closestPageToPosition(anchor)?.nextKey?.minus(1)

--- a/client/data/src/main/java/com/andone/memorip/data/tag/datasource/TagService.kt
+++ b/client/data/src/main/java/com/andone/memorip/data/tag/datasource/TagService.kt
@@ -6,8 +6,7 @@ import retrofit2.http.GET
 import retrofit2.http.Query
 
 interface TagService {
-
-    @GET
+    @GET("/api/tags")
     suspend fun getTags(
         @Query("page") page: Int,
         @Query("size") size: Int,

--- a/client/data/src/main/java/com/andone/memorip/data/tag/datasource/TagService.kt
+++ b/client/data/src/main/java/com/andone/memorip/data/tag/datasource/TagService.kt
@@ -1,0 +1,15 @@
+package com.andone.memorip.data.tag.datasource
+
+import com.andone.memorip.data.common.ApiResult
+import com.andone.memorip.data.tag.model.TagListItemResponse
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface TagService {
+
+    @GET
+    suspend fun getTags(
+        @Query("page") page: Int,
+        @Query("size") size: Int,
+    ): ApiResult<List<TagListItemResponse>>
+}

--- a/client/data/src/main/java/com/andone/memorip/data/tag/datasource/remote/TagRemoteDataSource.kt
+++ b/client/data/src/main/java/com/andone/memorip/data/tag/datasource/remote/TagRemoteDataSource.kt
@@ -1,0 +1,9 @@
+package com.andone.memorip.data.tag.datasource.remote
+
+import androidx.paging.PagingData
+import com.andone.memorip.domain.model.Tag
+import kotlinx.coroutines.flow.Flow
+
+interface TagRemoteDataSource {
+    fun getPlaceList(): Flow<PagingData<Tag>>
+}

--- a/client/data/src/main/java/com/andone/memorip/data/tag/datasource/remote/TagRemoteDataSourceImpl.kt
+++ b/client/data/src/main/java/com/andone/memorip/data/tag/datasource/remote/TagRemoteDataSourceImpl.kt
@@ -3,7 +3,6 @@ package com.andone.memorip.data.tag.datasource.remote
 import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
-import com.andone.memorip.data.place.datasource.remote.PlaceRemoteDataSourceImpl
 import com.andone.memorip.data.tag.datasource.TagListPagingSource
 import com.andone.memorip.data.tag.datasource.TagService
 import com.andone.memorip.domain.model.Tag

--- a/client/data/src/main/java/com/andone/memorip/data/tag/datasource/remote/TagRemoteDataSourceImpl.kt
+++ b/client/data/src/main/java/com/andone/memorip/data/tag/datasource/remote/TagRemoteDataSourceImpl.kt
@@ -1,0 +1,37 @@
+package com.andone.memorip.data.tag.datasource.remote
+
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.PagingData
+import com.andone.memorip.data.place.datasource.remote.PlaceRemoteDataSourceImpl
+import com.andone.memorip.data.tag.datasource.TagListPagingSource
+import com.andone.memorip.data.tag.datasource.TagService
+import com.andone.memorip.domain.model.Tag
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class TagRemoteDataSourceImpl @Inject constructor(private val tagService: TagService) :
+    TagRemoteDataSource {
+
+    override fun getPlaceList(): Flow<PagingData<Tag>> =
+        Pager(
+            config = PagingConfig(
+                pageSize = PAGE_SIZE,
+                enablePlaceholders = false,
+                initialLoadSize = PAGE_SIZE
+            ),
+            pagingSourceFactory = {
+                TagListPagingSource(
+                    service = tagService,
+                    pageSize = PAGE_SIZE
+                )
+            }
+        ).flow
+
+
+    companion object {
+        private const val PAGE_SIZE = 10
+    }
+}
+
+

--- a/client/data/src/main/java/com/andone/memorip/data/tag/model/TagListItemResponse.kt
+++ b/client/data/src/main/java/com/andone/memorip/data/tag/model/TagListItemResponse.kt
@@ -1,0 +1,18 @@
+package com.andone.memorip.data.tag.model
+
+import com.andone.memorip.domain.model.Tag
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TagListItemResponse(
+    val id: String,
+    val name: String,
+    val color: String
+)
+
+fun TagListItemResponse.toDomain(): Tag =
+    Tag(
+        id = id,
+        name = name,
+        color = color
+    )

--- a/client/data/src/main/java/com/andone/memorip/data/tag/model/TagListItemResponse.kt
+++ b/client/data/src/main/java/com/andone/memorip/data/tag/model/TagListItemResponse.kt
@@ -7,12 +7,12 @@ import kotlinx.serialization.Serializable
 data class TagListItemResponse(
     val id: String,
     val name: String,
-    val color: String
+    val colorHex: String
 )
 
 fun TagListItemResponse.toDomain(): Tag =
     Tag(
         id = id,
         name = name,
-        color = color
+        color = colorHex
     )

--- a/client/data/src/main/java/com/andone/memorip/data/tag/repositoryimpl/TagRepositoryImpl.kt
+++ b/client/data/src/main/java/com/andone/memorip/data/tag/repositoryimpl/TagRepositoryImpl.kt
@@ -1,0 +1,14 @@
+package com.andone.memorip.data.tag.repositoryimpl
+
+import androidx.paging.PagingData
+import com.andone.memorip.data.tag.datasource.remote.TagRemoteDataSource
+import com.andone.memorip.domain.model.Tag
+import com.andone.memorip.domain.repository.TagRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class TagRepositoryImpl @Inject constructor(private val tagRemoteDataSource: TagRemoteDataSource) : TagRepository {
+    override fun getTagList(): Flow<PagingData<Tag>> {
+        return tagRemoteDataSource.getPlaceList()
+    }
+}

--- a/client/data/src/main/java/com/andone/memorip/data/tag/repositoryimpl/TagRepositoryImpl.kt
+++ b/client/data/src/main/java/com/andone/memorip/data/tag/repositoryimpl/TagRepositoryImpl.kt
@@ -7,7 +7,9 @@ import com.andone.memorip.domain.repository.TagRepository
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
-class TagRepositoryImpl @Inject constructor(private val tagRemoteDataSource: TagRemoteDataSource) : TagRepository {
+class TagRepositoryImpl @Inject constructor(
+    private val tagRemoteDataSource: TagRemoteDataSource
+) : TagRepository {
     override fun getTagList(): Flow<PagingData<Tag>> {
         return tagRemoteDataSource.getPlaceList()
     }

--- a/client/domain/src/main/java/com/andone/memorip/domain/repository/PlaceRepository.kt
+++ b/client/domain/src/main/java/com/andone/memorip/domain/repository/PlaceRepository.kt
@@ -9,10 +9,17 @@ import com.andone.memorip.domain.model.response.PlaceDetailResponse
 import com.andone.memorip.domain.model.response.PlaceImageUploadResponse
 import kotlinx.coroutines.flow.Flow
 import java.io.File
+import java.util.UUID
 
 interface PlaceRepository {
     suspend fun getPlaceDetail(placeId: String): Result<PlaceDetailResponse>
-    fun getPlaceList(): Flow<PagingData<PlaceListItem>>
+    fun getPlaceList(
+        query: String? = null,
+        tagIds: List<UUID>? = null,
+        region1Depth: String? = null,
+        region2Depth: List<String>? = null,
+        sort: List<String>? = null
+    ): Flow<PagingData<PlaceListItem>>
     suspend fun uploadImage(file: File): Result<PlaceImageUploadResponse>
     suspend fun createPlace(place: PlaceCreateRequest): Result<PlaceCreateResponse>
     suspend fun updatePlaceGroups(

--- a/client/domain/src/main/java/com/andone/memorip/domain/repository/PlaceRepository.kt
+++ b/client/domain/src/main/java/com/andone/memorip/domain/repository/PlaceRepository.kt
@@ -15,7 +15,7 @@ interface PlaceRepository {
     suspend fun getPlaceDetail(placeId: String): Result<PlaceDetailResponse>
     fun getPlaceList(
         query: String? = null,
-        tagIds: List<UUID>? = null,
+        tagIds: List<String>? = null,
         region1Depth: String? = null,
         region2Depth: List<String>? = null,
         sort: List<String>? = null

--- a/client/domain/src/main/java/com/andone/memorip/domain/repository/TagRepository.kt
+++ b/client/domain/src/main/java/com/andone/memorip/domain/repository/TagRepository.kt
@@ -1,0 +1,9 @@
+package com.andone.memorip.domain.repository
+
+import androidx.paging.PagingData
+import com.andone.memorip.domain.model.Tag
+import kotlinx.coroutines.flow.Flow
+
+interface TagRepository {
+    fun getTagList(): Flow<PagingData<Tag>>
+}

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/component/Chip.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/component/Chip.kt
@@ -96,7 +96,7 @@ fun ClickableChip(
     radius: Dp = StaticChipDimen.RADIUS,
     isSelected: Boolean = false,
     colors: ChipColors = ChipColors.Default,
-    textStyle: TextStyle = MemoripTheme.typography.bodyBold12,
+    textStyle: TextStyle = MemoripTheme.typography.bodyBold14,
     elevation: Dp = 0.dp,
     onClick: () -> Unit = {}
 ) {

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/component/Chip.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/component/Chip.kt
@@ -1,21 +1,30 @@
 package com.andone.memorip.presentation.component
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.andone.memorip.presentation.R
+import com.andone.memorip.presentation.theme.MemoripIconSize
 import com.andone.memorip.presentation.theme.MemoripLineWidth
 import com.andone.memorip.presentation.theme.MemoripPadding
+import com.andone.memorip.presentation.theme.MemoripSpace
 import com.andone.memorip.presentation.theme.MemoripTheme
 
 private object StaticChipDimen {
@@ -85,6 +94,7 @@ fun ClickableChip(
     chipName: String,
     modifier: Modifier = Modifier,
     radius: Dp = StaticChipDimen.RADIUS,
+    isSelected: Boolean = false,
     colors: ChipColors = ChipColors.Default,
     textStyle: TextStyle = MemoripTheme.typography.bodyBold12,
     elevation: Dp = 0.dp,
@@ -103,15 +113,29 @@ fun ClickableChip(
             )
         }
     ) {
-        Text(
-            text = chipName,
+        Row(
             modifier = Modifier.padding(
                 horizontal = MemoripPadding.PaddingSmall,
                 vertical = MemoripPadding.PaddingXXSmall
             ),
-            style = textStyle,
-            color = colors.textColor
-        )
+            horizontalArrangement = Arrangement.spacedBy(space = MemoripSpace.SpaceXXSmall),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            if (isSelected) {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_check),
+                    contentDescription = null,
+                    tint = colors.textColor,
+                    modifier = Modifier.size(MemoripIconSize.IconSizeXSmall)
+                )
+            }
+
+            Text(
+                text = chipName,
+                style = textStyle,
+                color = colors.textColor
+            )
+        }
     }
 }
 

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/component/MemoripPagingList.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/component/MemoripPagingList.kt
@@ -4,6 +4,8 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyHorizontalGrid
 import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
 import androidx.compose.runtime.Composable
@@ -25,6 +27,8 @@ fun <T : Any> MemoripPagingList(
     emptyContent: @Composable () -> Unit,
     modifier: Modifier = Modifier,
     staggeredCells: StaggeredGridCells? = null,
+    useHorizontalGrid: Boolean = false,
+    horizontalGridRows: Int = 3,
     itemContent: @Composable (T) -> Unit
 ) {
     val loadState = pagingItems.loadState
@@ -48,15 +52,33 @@ fun <T : Any> MemoripPagingList(
                 handleAppendState(loadState.append, pagingItems::retry)
             }
         } ?: run {
-            LazyColumn(modifier = modifier) {
-                items(
-                    count = pagingItems.itemCount,
-                    key = pagingItems.itemKey { itemKey(it) }
-                ) { index ->
-                    pagingItems[index]?.let { itemContent(it) }
-                }
+            if (useHorizontalGrid) {
+                LazyHorizontalGrid(
+                    rows = GridCells.Fixed(horizontalGridRows),
+                    modifier = modifier,
+                    horizontalArrangement = Arrangement.spacedBy(MemoripSpace.SpaceSmall),
+                    verticalArrangement = Arrangement.spacedBy(MemoripSpace.SpaceSmall)
+                ) {
+                    items(
+                        count = pagingItems.itemCount,
+                        key = pagingItems.itemKey { itemKey(it) }
+                    ) { index ->
+                        pagingItems[index]?.let { itemContent(it) }
+                    }
 
-                handleAppendState(loadState.append, pagingItems::retry)
+                    handleAppendState(loadState.append, pagingItems::retry)
+                }
+            } else {
+                LazyColumn(modifier = modifier) {
+                    items(
+                        count = pagingItems.itemCount,
+                        key = pagingItems.itemKey { itemKey(it) }
+                    ) { index ->
+                        pagingItems[index]?.let { itemContent(it) }
+                    }
+
+                    handleAppendState(loadState.append, pagingItems::retry)
+                }
             }
         }
         return

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/component/MemoripStaggeredGrid.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/component/MemoripStaggeredGrid.kt
@@ -108,6 +108,7 @@ fun StaggeredImageItem(
                     text = contentDescription?.takeIf { it.isNotBlank() }
                         ?: stringResource(R.string.place_list_no_title),
                     style = MemoripTheme.typography.labelRegular10,
+                    maxLines = 1,
                     overflow = TextOverflow.Ellipsis
                 )
                 Spacer(modifier = Modifier.height(height = MemoripPadding.PaddingXXSmall))
@@ -138,7 +139,7 @@ private fun StaggeredImageItemPreview() {
         StaggeredImageItem(
             imageUrl = "https://picsum.photos/id/1/200/300",
             aspectRatio = 1f,
-            onImageClick = {}
+            onImageClick = {},
         )
     }
 }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/component/MemoripStaggeredGrid.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/component/MemoripStaggeredGrid.kt
@@ -107,7 +107,7 @@ fun StaggeredImageItem(
                 Text(
                     text = contentDescription?.takeIf { it.isNotBlank() }
                         ?: stringResource(R.string.place_list_no_title),
-                    style = MemoripTheme.typography.labelRegular10,
+                    style = MemoripTheme.typography.bodyBold14,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
                 )

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/component/PlaceAttributeContents.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/component/PlaceAttributeContents.kt
@@ -56,7 +56,7 @@ fun PlaceLocationText(
         Text(
             text = address,
             color = MemoripTheme.colors.onSurface,
-            style = MemoripTheme.typography.labelRegular10,
+            style = MemoripTheme.typography.bodyBold12,
             maxLines = maxLines,
             overflow = TextOverflow.Ellipsis
         )

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/component/TagChip.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/component/TagChip.kt
@@ -45,6 +45,8 @@ fun StaticTagChip(
 fun ClickableTagChip(
     tag: TagUiModel,
     modifier: Modifier = Modifier,
+    isSelected: Boolean = false,
+    onClick: () -> Unit = {}
 ) {
     val textColor = if (tag.color.luminance() > TagChipDimen.COLOR_LUMINANCE_THRESHOLD) {
         MemoripTheme.colors.black
@@ -56,10 +58,12 @@ fun ClickableTagChip(
         chipName = tag.name,
         modifier = modifier,
         radius = TagChipDimen.CLICKABLE_CHIP_RADIUS,
+        isSelected = isSelected,
         colors = ChipColors(
             backgroundColor = tag.color.copy(alpha = TagChipDimen.BACKGROUND_COLOR_ALPHA),
             textColor = textColor
-        )
+        ),
+        onClick = onClick
     )
 }
 

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placelist/PlaceListScreen.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placelist/PlaceListScreen.kt
@@ -125,6 +125,7 @@ fun PlaceListScreenContent(
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
 
     var showRegionBottomSheet by remember { mutableStateOf(value = false) }
+    var showTagBottomSheet by remember { mutableStateOf(false) }
 
     var isFilterVisible by remember { mutableStateOf(value = true) }
     val clearFocusOnScroll = remember {
@@ -163,6 +164,17 @@ fun PlaceListScreenContent(
         }
     }
 
+    if (showTagBottomSheet) {
+        ModalBottomSheet(
+            onDismissRequest = { showTagBottomSheet = false },
+            sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+            containerColor = MemoripTheme.colors.background,
+            contentColor = MemoripTheme.colors.onSurface
+        ) {
+
+        }
+    }
+
     Scaffold(
         modifier = modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
@@ -183,9 +195,9 @@ fun PlaceListScreenContent(
                 Column {
                     FilterSection(
                         onChangeRegionClick = { showRegionBottomSheet = true },
-                        onAddTagClick = {},
+                        onAddTagClick = { showTagBottomSheet = true},
                         modifier = Modifier.padding(horizontal = MemoripPadding.AppHorizontalPadding),
-                        tags = DummyData.categories.toImmutableList(),
+                        tags = state.selectedTags.toImmutableList(),
                         selectedRegionState = state.selectedRegionState
                     )
                     Spacer(modifier = Modifier.padding(vertical = MemoripPadding.PaddingXSmall))

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placelist/PlaceListScreen.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placelist/PlaceListScreen.kt
@@ -210,7 +210,8 @@ fun PlaceListScreenContent(
                         onAddTagClick = { showTagBottomSheet = true },
                         modifier = Modifier.padding(horizontal = MemoripPadding.AppHorizontalPadding),
                         tags = state.selectedTags.toImmutableList(),
-                        selectedRegionState = state.selectedRegionState
+                        selectedRegionState = state.selectedRegionState,
+                        onChipClick = { onAction(PlaceListAction.OnDeleteTagClick(tag = it)) }
                     )
                     Spacer(modifier = Modifier.padding(vertical = MemoripPadding.PaddingXSmall))
                 }
@@ -235,6 +236,7 @@ private fun FilterSection(
     modifier: Modifier = Modifier,
     tags: ImmutableList<TagUiModel> = persistentListOf(),
     selectedRegionState: SelectedRegionState = SelectedRegionState(),
+    onChipClick: (tagUiModel: TagUiModel) -> Unit = {}
 ) {
     Column(modifier = modifier) {
         RegionFilter(
@@ -243,7 +245,8 @@ private fun FilterSection(
         )
         TagFilter(
             tags = tags,
-            onAddTagClick = onAddTagClick
+            onAddTagClick = onAddTagClick,
+            onChipClick = onChipClick
         )
     }
 }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placelist/PlaceListScreen.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placelist/PlaceListScreen.kt
@@ -53,6 +53,7 @@ import com.andone.memorip.presentation.screen.placelist.component.PlaceListTopBa
 import com.andone.memorip.presentation.screen.placelist.component.RegionFilter
 import com.andone.memorip.presentation.screen.placelist.component.RegionSelectBottomSheet
 import com.andone.memorip.presentation.screen.placelist.component.TagFilter
+import com.andone.memorip.presentation.screen.placelist.component.TagSelectBottomSheet
 import com.andone.memorip.presentation.screen.placelist.model.PlaceListAction
 import com.andone.memorip.presentation.screen.placelist.model.PlaceListEvent
 import com.andone.memorip.presentation.screen.placelist.model.PlaceListUiState
@@ -85,6 +86,8 @@ fun PlaceListScreen(
 
     val placesPagingItems = viewModel.placesPagingFlow.collectAsLazyPagingItems()
 
+    val tagPagingItems = viewModel.tagsPagingFlow.collectAsLazyPagingItems()
+
     viewModel.event.collectWithLifecycle { event ->
         when (event) {
             is PlaceListEvent.NavigateToPlaceCreate -> {
@@ -108,6 +111,7 @@ fun PlaceListScreen(
     PlaceListScreenContent(
         state = uiState,
         placePagingItems = placesPagingItems,
+        tagPagingItems = tagPagingItems,
         onAction = viewModel::onAction,
         modifier = modifier
     )
@@ -118,6 +122,7 @@ fun PlaceListScreen(
 fun PlaceListScreenContent(
     state: PlaceListUiState,
     placePagingItems: LazyPagingItems<Place>,
+    tagPagingItems: LazyPagingItems<TagUiModel>,
     onAction: (PlaceListAction) -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -171,7 +176,10 @@ fun PlaceListScreenContent(
             containerColor = MemoripTheme.colors.background,
             contentColor = MemoripTheme.colors.onSurface
         ) {
-
+            TagSelectBottomSheet(
+                tagPagingItems = tagPagingItems,
+                selectedTags = state.selectedTags.toImmutableList(),
+            )
         }
     }
 
@@ -296,6 +304,7 @@ private fun PlaceListScreenContentsPreview() {
         PlaceListScreenContent(
             state = PlaceListUiState(),
             placePagingItems = DummyData.getPlacePagingItems(),
+            tagPagingItems = DummyData.getTagPagingItems(),
             onAction = {},
         )
     }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placelist/PlaceListScreen.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placelist/PlaceListScreen.kt
@@ -164,7 +164,8 @@ fun PlaceListScreenContent(
                 currentRegionList = state.currentRegionList,
                 selectedRegionState = state.selectedRegionState,
                 onConfirmClick = { showRegionBottomSheet = false },
-                onRegionChipClick = { onAction(PlaceListAction.OnRegionChipClick(region = it)) }
+                onRegionChipClick = { onAction(PlaceListAction.OnRegionChipClick(region = it)) },
+                onResetClick = { onAction(PlaceListAction.ClearRegionFilter) }
             )
         }
     }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placelist/PlaceListScreen.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placelist/PlaceListScreen.kt
@@ -178,7 +178,10 @@ fun PlaceListScreenContent(
         ) {
             TagSelectBottomSheet(
                 tagPagingItems = tagPagingItems,
-                selectedTags = state.selectedTags.toImmutableList(),
+                selectedTags = state.selectedTags,
+                onConfirmClick = { showTagBottomSheet = false },
+                onTagChipClick = { onAction(PlaceListAction.OnTagChipClick(tag = it)) },
+                onDeselectClick = { onAction(PlaceListAction.OnDeleteTagClick(tag = it)) }
             )
         }
     }
@@ -203,7 +206,7 @@ fun PlaceListScreenContent(
                 Column {
                     FilterSection(
                         onChangeRegionClick = { showRegionBottomSheet = true },
-                        onAddTagClick = { showTagBottomSheet = true},
+                        onAddTagClick = { showTagBottomSheet = true },
                         modifier = Modifier.padding(horizontal = MemoripPadding.AppHorizontalPadding),
                         tags = state.selectedTags.toImmutableList(),
                         selectedRegionState = state.selectedRegionState

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placelist/PlaceListViewModel.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placelist/PlaceListViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.paging.cachedIn
 import androidx.paging.map
 import com.andone.memorip.domain.repository.PlaceRepository
+import com.andone.memorip.domain.repository.TagRepository
 import com.andone.memorip.presentation.model.toUiModel
 import com.andone.memorip.presentation.screen.placelist.model.PlaceListAction
 import com.andone.memorip.presentation.screen.placelist.model.PlaceListEvent
@@ -23,7 +24,10 @@ import kotlinx.coroutines.flow.update
 import javax.inject.Inject
 
 @HiltViewModel
-class PlaceListViewModel @Inject constructor(repository: PlaceRepository) : ViewModel() {
+class PlaceListViewModel @Inject constructor(
+    repository: PlaceRepository,
+    tagRepository: TagRepository
+) : ViewModel() {
 
     private val _uiState = MutableStateFlow(value = PlaceListUiState())
     val uiState = _uiState.asStateFlow()
@@ -41,6 +45,13 @@ class PlaceListViewModel @Inject constructor(repository: PlaceRepository) : View
 
     val placesPagingFlow =
         repository.getPlaceList()
+            .map { pagingData ->
+                pagingData.map { it.toUiModel() }
+            }
+            .cachedIn(viewModelScope)
+
+    val tagsPagingFlow =
+        tagRepository.getTagList()
             .map { pagingData ->
                 pagingData.map { it.toUiModel() }
             }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placelist/PlaceListViewModel.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placelist/PlaceListViewModel.kt
@@ -14,13 +14,20 @@ import com.andone.memorip.presentation.screen.placelist.model.RegionUiModel
 import com.andone.memorip.presentation.screen.placelist.model.SelectedRegionState
 import com.andone.memorip.presentation.screen.placelist.model.toUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.BUFFERED
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
+import java.util.UUID
 import javax.inject.Inject
 
 @HiltViewModel
@@ -35,16 +42,33 @@ class PlaceListViewModel @Inject constructor(
     private val _event = Channel<PlaceListEvent>(capacity = BUFFERED)
     val event = _event.receiveAsFlow()
 
-    init {
-        val rootRegions = repository.loadRegions().map { it.toUiModel() }
+    @OptIn(FlowPreview::class)
+    private val queryFlow = uiState
+        .map { it.query }
+        .debounce(300)
+        .distinctUntilChanged()
 
-        _uiState.update {
-            it.copy(rootRegions = rootRegions)
+    private val filterFlow = uiState
+        .map { state ->
+            Triple(
+                state.selectedTags.mapNotNull { UUID.fromString(it.id) },
+                state.selectedRegionState.parents.firstOrNull()?.name,
+                state.selectedRegionState.child.map { it.name }
+            )
         }
-    }
+        .distinctUntilChanged()
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     val placesPagingFlow =
-        repository.getPlaceList()
+        combine(queryFlow, filterFlow) { query, (tagIds, region1Depth, region2Depth) ->
+            repository.getPlaceList(
+                query = query,
+                tagIds = tagIds,
+                region1Depth = region1Depth,
+                region2Depth = region2Depth
+            )
+        }
+            .flatMapLatest { it }
             .map { pagingData ->
                 pagingData.map { it.toUiModel() }
             }
@@ -56,6 +80,14 @@ class PlaceListViewModel @Inject constructor(
                 pagingData.map { it.toUiModel() }
             }
             .cachedIn(viewModelScope)
+
+    init {
+        val rootRegions = repository.loadRegions().map { it.toUiModel() }
+
+        _uiState.update {
+            it.copy(rootRegions = rootRegions)
+        }
+    }
 
     fun onAction(action: PlaceListAction) {
         when (action) {

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placelist/PlaceListViewModel.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placelist/PlaceListViewModel.kt
@@ -45,7 +45,7 @@ class PlaceListViewModel @Inject constructor(
     @OptIn(FlowPreview::class)
     private val queryFlow = uiState
         .map { it.query }
-        .debounce(300)
+        .debounce(timeoutMillis = QUERY_DEBOUNCE_TIME)
         .distinctUntilChanged()
 
     private val filterFlow = uiState
@@ -63,7 +63,7 @@ class PlaceListViewModel @Inject constructor(
             }
 
             Triple(
-                state.selectedTags.mapNotNull { UUID.fromString(it.id) },
+                state.selectedTags.map { it.id },
                 depth1,
                 depth2
             )
@@ -195,5 +195,9 @@ class PlaceListViewModel @Inject constructor(
 
             state.copy(selectedRegionState = nextState)
         }
+    }
+
+    companion object {
+        private const val QUERY_DEBOUNCE_TIME = 300L
     }
 }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placelist/PlaceListViewModel.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placelist/PlaceListViewModel.kt
@@ -50,10 +50,22 @@ class PlaceListViewModel @Inject constructor(
 
     private val filterFlow = uiState
         .map { state ->
+            val regionState = state.selectedRegionState
+            val parents = regionState.parents
+            val child = regionState.child
+
+            val depth1 = parents.firstOrNull()?.name
+
+            val depth2 = when {
+                child.isNotEmpty() -> child.map { it.name }
+                parents.size >= 2 -> listOf(parents.last().name)
+                else -> emptyList()
+            }
+
             Triple(
                 state.selectedTags.mapNotNull { UUID.fromString(it.id) },
-                state.selectedRegionState.parents.firstOrNull()?.name,
-                state.selectedRegionState.child.map { it.name }
+                depth1,
+                depth2
             )
         }
         .distinctUntilChanged()
@@ -117,6 +129,12 @@ class PlaceListViewModel @Inject constructor(
 
             is PlaceListAction.OnDeleteTagClick -> {
                 _uiState.update { it.copy(selectedTags = it.selectedTags - action.tag) }
+            }
+
+            PlaceListAction.ClearRegionFilter -> {
+                _uiState.update {
+                    it.copy(selectedRegionState = SelectedRegionState())
+                }
             }
         }
     }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placelist/PlaceListViewModel.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placelist/PlaceListViewModel.kt
@@ -78,6 +78,14 @@ class PlaceListViewModel @Inject constructor(
             is PlaceListAction.OnRegionChipClick -> {
                 onRegionClicked(region = action.region)
             }
+
+            is PlaceListAction.OnTagChipClick -> {
+                _uiState.update { it.copy(selectedTags = it.selectedTags + action.tag) }
+            }
+
+            is PlaceListAction.OnDeleteTagClick -> {
+                _uiState.update { it.copy(selectedTags = it.selectedTags - action.tag) }
+            }
         }
     }
 

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placelist/component/RegionSelectBottomSheet.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placelist/component/RegionSelectBottomSheet.kt
@@ -3,12 +3,14 @@ package com.andone.memorip.presentation.screen.placelist.component
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -32,16 +34,30 @@ fun RegionSelectBottomSheet(
     selectedRegionState: SelectedRegionState = SelectedRegionState(),
     onConfirmClick: () -> Unit = {},
     onRegionChipClick: (regionUiModel: RegionUiModel) -> Unit = {},
+    onResetClick: () -> Unit = {},
 ) {
     Column(
         modifier = modifier.padding(horizontal = MemoripPadding.AppHorizontalPadding),
         verticalArrangement = Arrangement.spacedBy(space = MemoripSpace.SpaceMedium)
     ) {
-        Text(
-            text = stringResource(R.string.place_list_bottom_sheet_title),
-            modifier = Modifier.align(Alignment.CenterHorizontally),
-            style = MemoripTheme.typography.headlineBold20
-        )
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = stringResource(R.string.place_list_bottom_sheet_title),
+                style = MemoripTheme.typography.headlineBold20
+            )
+
+            TextButton(onClick = onResetClick) {
+                Text(
+                    text = stringResource(R.string.place_list_reset),
+                    style = MemoripTheme.typography.labelMedium14,
+                    color = MemoripTheme.colors.primary
+                )
+            }
+        }
 
         RegionPathRow(
             selectedRegionState = selectedRegionState,

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placelist/component/TagFilter.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placelist/component/TagFilter.kt
@@ -28,7 +28,8 @@ import com.andone.memorip.presentation.component.ClickableTagChip
 fun TagFilter(
     tags: ImmutableList<TagUiModel>,
     modifier: Modifier = Modifier,
-    onAddTagClick: () -> Unit = {}
+    onAddTagClick: () -> Unit = {},
+    onChipClick: (tagUiModel: TagUiModel) -> Unit = {}
 ) {
     Row(
         modifier = modifier
@@ -36,7 +37,7 @@ fun TagFilter(
             .horizontalScroll(state = rememberScrollState()),
         horizontalArrangement = Arrangement.spacedBy(space = MemoripSpace.SpaceXSmall)
     ) {
-        tags.forEach { tag -> ClickableTagChip(tag = tag) }
+        tags.forEach { tag -> ClickableTagChip(tag = tag, onClick = { onChipClick(tag) }) }
         IconButton(onClick = onAddTagClick) {
             Icon(
                 painter = painterResource(R.drawable.ic_outline_add_circle),

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placelist/component/TagSelectBottomSheet.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placelist/component/TagSelectBottomSheet.kt
@@ -32,7 +32,7 @@ import com.andone.memorip.presentation.theme.MemoripTheme
 import com.andone.memorip.presentation.theme.memoripShapes
 import com.andone.memorip.presentation.util.DummyData
 
-private object TagSelectBottomSheetConstant{
+private object TagSelectBottomSheetConstant {
     val TAG_LIST_HEIGHT = 104.dp
 }
 
@@ -40,9 +40,10 @@ private object TagSelectBottomSheetConstant{
 fun TagSelectBottomSheet(
     modifier: Modifier = Modifier,
     tagPagingItems: LazyPagingItems<TagUiModel>,
-    selectedTags: List<TagUiModel> = emptyList(),
+    selectedTags: Set<TagUiModel> = emptySet(),
     onConfirmClick: () -> Unit = {},
     onTagChipClick: (tagUiModel: TagUiModel) -> Unit = {},
+    onDeselectClick: (tagUiModel: TagUiModel) -> Unit = {},
 ) {
     Column(
         modifier = modifier.padding(horizontal = MemoripPadding.AppHorizontalPadding),
@@ -67,7 +68,9 @@ fun TagSelectBottomSheet(
 
         TagListSection(
             tagPagingItems = tagPagingItems,
-            onChipClick = onTagChipClick
+            selectedTags = selectedTags,
+            onChipClick = onTagChipClick,
+            onDeselectClick = onDeselectClick,
         )
 
         HorizontalDivider()
@@ -92,10 +95,14 @@ fun TagSelectBottomSheet(
 
 @Composable
 private fun TagListSection(
-    modifier: Modifier = Modifier,
     tagPagingItems: LazyPagingItems<TagUiModel>,
-    onChipClick: (tagUiModel: TagUiModel) -> Unit = {}
+    modifier: Modifier = Modifier,
+    selectedTags: Set<TagUiModel> = emptySet(),
+    onChipClick: (tagUiModel: TagUiModel) -> Unit = {},
+    onDeselectClick: (tagUiModel: TagUiModel) -> Unit = {},
 ) {
+    val selectedIds = selectedTags.map { it.id }.toSet()
+
     MemoripPagingList(
         pagingItems = tagPagingItems,
         itemKey = { it.id },
@@ -110,7 +117,17 @@ private fun TagListSection(
             .height(height = TAG_LIST_HEIGHT),
         useHorizontalGrid = true,
         itemContent = {
-            ClickableTagChip(tag = it)
+            ClickableTagChip(
+                tag = it,
+                isSelected = selectedIds.contains(it.id),
+                onClick = {
+                    if (selectedIds.contains(it.id)) {
+                        onDeselectClick(it)
+                    } else {
+                        onChipClick(it)
+                    }
+                }
+            )
         },
     )
 }
@@ -121,7 +138,7 @@ private fun TagSelectBottomSheetPreview() {
     MemoripTheme {
         TagSelectBottomSheet(
             tagPagingItems = DummyData.getTagPagingItems(),
-            selectedTags = DummyData.categories.toList()
+            selectedTags = DummyData.categories.toSet()
         )
     }
 }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placelist/component/TagSelectBottomSheet.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placelist/component/TagSelectBottomSheet.kt
@@ -33,7 +33,7 @@ import com.andone.memorip.presentation.theme.memoripShapes
 import com.andone.memorip.presentation.util.DummyData
 
 private object TagSelectBottomSheetConstant {
-    val TAG_LIST_HEIGHT = 104.dp
+    val TAG_LIST_HEIGHT = 120.dp
 }
 
 @Composable

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placelist/component/TagSelectBottomSheet.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placelist/component/TagSelectBottomSheet.kt
@@ -1,10 +1,14 @@
 package com.andone.memorip.presentation.screen.placelist.component
 
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.HorizontalDivider
@@ -14,45 +18,56 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.paging.compose.LazyPagingItems
 import com.andone.memorip.presentation.R
-import com.andone.memorip.presentation.component.ClickableChip
-import com.andone.memorip.presentation.component.ChipColors
-import com.andone.memorip.presentation.screen.placelist.model.RegionUiModel
-import com.andone.memorip.presentation.screen.placelist.model.SelectedRegionState
+import com.andone.memorip.presentation.component.ClickableTagChip
+import com.andone.memorip.presentation.component.EmptyText
+import com.andone.memorip.presentation.component.MemoripPagingList
+import com.andone.memorip.presentation.model.TagUiModel
+import com.andone.memorip.presentation.screen.placelist.component.TagSelectBottomSheetConstant.TAG_LIST_HEIGHT
 import com.andone.memorip.presentation.theme.MemoripPadding
 import com.andone.memorip.presentation.theme.MemoripSpace
 import com.andone.memorip.presentation.theme.MemoripTheme
 import com.andone.memorip.presentation.theme.memoripShapes
 import com.andone.memorip.presentation.util.DummyData
 
+private object TagSelectBottomSheetConstant{
+    val TAG_LIST_HEIGHT = 104.dp
+}
+
 @Composable
-fun RegionSelectBottomSheet(
+fun TagSelectBottomSheet(
     modifier: Modifier = Modifier,
-    currentRegionList: List<RegionUiModel> = emptyList(),
-    selectedRegionState: SelectedRegionState = SelectedRegionState(),
+    tagPagingItems: LazyPagingItems<TagUiModel>,
+    selectedTags: List<TagUiModel> = emptyList(),
     onConfirmClick: () -> Unit = {},
-    onRegionChipClick: (regionUiModel: RegionUiModel) -> Unit = {},
+    onTagChipClick: (tagUiModel: TagUiModel) -> Unit = {},
 ) {
     Column(
         modifier = modifier.padding(horizontal = MemoripPadding.AppHorizontalPadding),
         verticalArrangement = Arrangement.spacedBy(space = MemoripSpace.SpaceMedium)
     ) {
         Text(
-            text = stringResource(R.string.place_list_bottom_sheet_title),
+            text = stringResource(R.string.place_list_add_tag),
             modifier = Modifier.align(Alignment.CenterHorizontally),
             style = MemoripTheme.typography.headlineBold20
         )
 
-        RegionPathRow(
-            selectedRegionState = selectedRegionState,
-            isUnderline = true
-        )
+        Row(
+            modifier = modifier
+                .fillMaxWidth()
+                .horizontalScroll(state = rememberScrollState()),
+            horizontalArrangement = Arrangement.spacedBy(space = MemoripSpace.SpaceXSmall)
+        ) {
+            selectedTags.forEach { tag -> ClickableTagChip(tag = tag) }
+        }
 
         HorizontalDivider()
 
         TagListSection(
-            regionList = currentRegionList,
-            onChipClick = onRegionChipClick
+            tagPagingItems = tagPagingItems,
+            onChipClick = onTagChipClick
         )
 
         HorizontalDivider()
@@ -78,35 +93,35 @@ fun RegionSelectBottomSheet(
 @Composable
 private fun TagListSection(
     modifier: Modifier = Modifier,
-    regionList: List<RegionUiModel> = emptyList(),
-    onChipClick: (regionUiModel: RegionUiModel) -> Unit = {}
+    tagPagingItems: LazyPagingItems<TagUiModel>,
+    onChipClick: (tagUiModel: TagUiModel) -> Unit = {}
 ) {
-    FlowRow(
-        modifier = modifier,
-        horizontalArrangement = Arrangement.spacedBy(space = MemoripSpace.SpaceSmall),
-    ) {
-        regionList.forEach { region ->
-            ClickableChip(
-                chipName = region.name,
-                colors =
-                    if (region.isSelected) {
-                        ChipColors.Selected
-                    } else {
-                        ChipColors.Default
-                    },
-                onClick = { onChipClick(region) }
+    MemoripPagingList(
+        pagingItems = tagPagingItems,
+        itemKey = { it.id },
+        emptyContent = {
+            EmptyText(
+                text = stringResource(R.string.place_list_empty),
+                modifier = Modifier.fillMaxSize()
             )
-        }
-    }
+        },
+        modifier = modifier
+            .padding(horizontal = MemoripPadding.AppHorizontalPadding)
+            .height(height = TAG_LIST_HEIGHT),
+        useHorizontalGrid = true,
+        itemContent = {
+            ClickableTagChip(tag = it)
+        },
+    )
 }
 
 @Preview(showBackground = true)
 @Composable
-private fun RegionSelectBottomSheetPreview() {
+private fun TagSelectBottomSheetPreview() {
     MemoripTheme {
-        RegionSelectBottomSheet(
-            currentRegionList = DummyData.regions.toList(),
-            selectedRegionState = DummyData.regionState
+        TagSelectBottomSheet(
+            tagPagingItems = DummyData.getTagPagingItems(),
+            selectedTags = DummyData.categories.toList()
         )
     }
 }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placelist/model/PlaceListAction.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placelist/model/PlaceListAction.kt
@@ -1,5 +1,7 @@
 package com.andone.memorip.presentation.screen.placelist.model
 
+import com.andone.memorip.presentation.model.TagUiModel
+
 sealed interface PlaceListAction {
 
     data object OnFABClick : PlaceListAction
@@ -11,4 +13,8 @@ sealed interface PlaceListAction {
     data object OnRefreshPull : PlaceListAction
 
     data class OnRegionChipClick(val region: RegionUiModel) : PlaceListAction
+
+    data class OnTagChipClick(val tag: TagUiModel) : PlaceListAction
+
+    data class OnDeleteTagClick(val tag: TagUiModel) : PlaceListAction
 }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placelist/model/PlaceListAction.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placelist/model/PlaceListAction.kt
@@ -17,4 +17,6 @@ sealed interface PlaceListAction {
     data class OnTagChipClick(val tag: TagUiModel) : PlaceListAction
 
     data class OnDeleteTagClick(val tag: TagUiModel) : PlaceListAction
+
+    data object ClearRegionFilter : PlaceListAction
 }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placelist/model/PlaceListUiState.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placelist/model/PlaceListUiState.kt
@@ -6,7 +6,6 @@ data class PlaceListUiState(
     val query: String = "",
     val rootRegions: List<RegionUiModel> = emptyList(),
     val selectedRegionState: SelectedRegionState = SelectedRegionState(),
-    val tags: List<TagUiModel> = emptyList(),
     val selectedTags: Set<TagUiModel> = emptySet()
 ) {
     val currentRegionList: List<RegionUiModel>

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placelist/model/PlaceListUiState.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placelist/model/PlaceListUiState.kt
@@ -1,9 +1,13 @@
 package com.andone.memorip.presentation.screen.placelist.model
 
+import com.andone.memorip.presentation.model.TagUiModel
+
 data class PlaceListUiState(
     val query: String = "",
     val rootRegions: List<RegionUiModel> = emptyList(),
     val selectedRegionState: SelectedRegionState = SelectedRegionState(),
+    val tags: List<TagUiModel> = emptyList(),
+    val selectedTags: Set<TagUiModel> = emptySet()
 ) {
     val currentRegionList: List<RegionUiModel>
         get() {

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/util/AppendState.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/util/AppendState.kt
@@ -3,6 +3,7 @@ package com.andone.memorip.presentation.util
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.grid.LazyGridScope
 import androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridScope
 import androidx.compose.ui.Modifier
 import androidx.paging.LoadState
@@ -42,6 +43,37 @@ fun LazyStaggeredGridScope.handleAppendState(
 }
 
 fun LazyListScope.handleAppendState(
+    appendState: LoadState,
+    onRetry: () -> Unit
+) {
+    when (appendState) {
+        is LoadState.Loading -> {
+            item {
+                LoadingIndicatorScreen(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = MemoripPadding.PaddingMedium)
+                )
+            }
+        }
+
+        is LoadState.Error -> {
+            item {
+                ErrorScreen(
+                    onRetry = onRetry,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = MemoripPadding.PaddingMedium),
+                    message = appendState.error.localizedMessage
+                )
+            }
+        }
+
+        is LoadState.NotLoading -> {}
+    }
+}
+
+fun LazyGridScope.handleAppendState(
     appendState: LoadState,
     onRetry: () -> Unit
 ) {

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/util/DummyData.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/util/DummyData.kt
@@ -343,6 +343,11 @@ object DummyData {
     }
 
     @Composable
+    fun getTagPagingItems(): LazyPagingItems<TagUiModel> {
+        return flowOf(PagingData.from(categories)).collectAsLazyPagingItems()
+    }
+
+    @Composable
     fun getLocationPagingItems(): LazyPagingItems<LocationUiModel> {
         return flowOf(PagingData.from(locations)).collectAsLazyPagingItems()
     }

--- a/client/presentation/src/main/res/values/strings.xml
+++ b/client/presentation/src/main/res/values/strings.xml
@@ -138,6 +138,7 @@
     <string name="place_list_add_tag">태그 추가</string>
     <string name="place_list_no_address_info">위치 정보가 없습니다</string>
     <string name="place_list_no_title">제목 없음</string>
+    <string name="place_list_reset">초기화</string>
 
 
     <!-- PlanScreen -->


### PR DESCRIPTION
## 📝 변경 사항
홈화면(장소 목록)에 검색어, 태그, 지역 필터링 기능을 구현했습니다. 사용자는 여러 조건을 조합하여 원하는 장소를 쉽게 찾을 수 있습니다.

## 🎯 작업 내용
### Data Layer
- Tag 관련 데이터 레이어 구현
  - `TagService`, `TagRepository`, `TagRemoteDataSource` 및 구현체 추가
  - `TagListPagingSource`를 통한 페이징 처리
  - DI 모듈 설정 (`DataSourceModule`, `RepositoryModule`, `ServerNetworkModule`)
- Place API에 필터링 파라미터 추가 (`query`, `tagIds`, `region1Depth`, `region2Depth`)
- `PlaceListPagingSource` 및 `PlaceRemoteDataSource`에 필터링 로직 적용

### Presentation Layer
- `TagSelectBottomSheet` 추가 - 태그 선택을 위한 바텀시트 UI
- `RegionSelectBottomSheet`에 초기화 버튼 추가
- `ClickableChip` 컴포넌트에 선택 상태 표시 기능 추가 (체크 아이콘)
- `MemoripPagingList`에 가로 그리드 레이아웃 지원 추가
- `PlaceListViewModel`에 필터링 로직 구현
  - Flow를 사용한 실시간 필터링 (검색어는 300ms debounce 적용)
  - `distinctUntilChanged`를 통한 중복 요청 방지
  - 태그 및 지역 필터 상태 관리

### 기타
- 타이포 수정: `TokenRefresher` → `bindTokenRefresher`
- 텍스트 스타일 개선 (일부 컴포넌트의 폰트 크기 조정)
- Paging 처리 개선 (LazyGridScope에 대한 appendState 핸들러 추가)

## 🔗 관련 이슈
Closes #163

## 💬 리뷰어에게
- 필터링 조합 로직이 의도대로 동작하는지 확인 부탁드립니다
- Tag 페이징 처리가 적절한지 검토 부탁드립니다

https://github.com/user-attachments/assets/f0ffffce-794b-4818-a57f-ce9bc8ca3ae0