### PR TITLE
[Feature] 장소 수정 API 연결, 장소 추가 주소 변환, 바텀 바 가로 대응

### DIFF
--- a/client/data/src/main/java/com/andone/memorip/data/place/datasource/PlaceService.kt
+++ b/client/data/src/main/java/com/andone/memorip/data/place/datasource/PlaceService.kt
@@ -47,6 +47,12 @@ interface PlaceService {
         @Body place: PlaceCreateUpdateRequest
     ): ApiResult<PlaceCreateResponse>
 
+    @PATCH("/api/places/{placeId}")
+    suspend fun updatePlace(
+        @Path("placeId") placeId: String,
+        @Body place: PlaceCreateUpdateRequest
+    ): ApiResult<PlaceDetailResponse>
+
     @DELETE("/api/places/{placeId}")
     suspend fun deletePlace(
         @Path("placeId") placeId: String

--- a/client/data/src/main/java/com/andone/memorip/data/place/datasource/remote/PlaceRemoteDataSource.kt
+++ b/client/data/src/main/java/com/andone/memorip/data/place/datasource/remote/PlaceRemoteDataSource.kt
@@ -23,6 +23,11 @@ interface PlaceRemoteDataSource {
 
     suspend fun uploadImage(file: File): Result<PlaceImageUploadResponse>
     suspend fun createPlace(place: PlaceCreateUpdateRequest): Result<PlaceCreateResponse>
+    suspend fun updatePlace(
+        placeId: String,
+        place: PlaceCreateUpdateRequest
+    ): Result<PlaceDetailResponse>
+
     suspend fun deletePlace(placeId: String): Result<Unit>
     suspend fun updatePlaceTrips(
         placeId: String,

--- a/client/data/src/main/java/com/andone/memorip/data/place/datasource/remote/PlaceRemoteDataSourceImpl.kt
+++ b/client/data/src/main/java/com/andone/memorip/data/place/datasource/remote/PlaceRemoteDataSourceImpl.kt
@@ -85,6 +85,13 @@ class PlaceRemoteDataSourceImpl @Inject constructor(
         return apiCall { placeService.createPlace(place) }
     }
 
+    override suspend fun updatePlace(
+        placeId: String,
+        place: PlaceCreateUpdateRequest
+    ): Result<PlaceDetailResponse> {
+        return apiCall { placeService.updatePlace(placeId, place) }
+    }
+
     override suspend fun deletePlace(placeId: String): Result<Unit> {
         return apiCall { placeService.deletePlace(placeId) }
     }

--- a/client/data/src/main/java/com/andone/memorip/data/place/repositoryimpl/PlaceRepositoryImpl.kt
+++ b/client/data/src/main/java/com/andone/memorip/data/place/repositoryimpl/PlaceRepositoryImpl.kt
@@ -47,6 +47,14 @@ class PlaceRepositoryImpl @Inject constructor(
             .map { it.toDomain() }
     }
 
+    override suspend fun updatePlace(
+        placeId: String,
+        place: PlaceCreateUpdate
+    ): Result<PlaceDetail> {
+        return placeRemoteDataSource.updatePlace(placeId, place.toDomain())
+            .map { it.toDomain() }
+    }
+
     override suspend fun deletePlace(placeId: String): Result<Unit> {
         return placeRemoteDataSource.deletePlace(placeId)
     }

--- a/client/domain/src/main/java/com/andone/memorip/domain/repository/PlaceRepository.kt
+++ b/client/domain/src/main/java/com/andone/memorip/domain/repository/PlaceRepository.kt
@@ -1,11 +1,11 @@
 package com.andone.memorip.domain.repository
 
 import androidx.paging.PagingData
-import com.andone.memorip.domain.model.response.PlaceDetail
 import com.andone.memorip.domain.model.PlaceListItem
 import com.andone.memorip.domain.model.Region
 import com.andone.memorip.domain.model.request.PlaceCreateUpdate
 import com.andone.memorip.domain.model.response.PlaceCreated
+import com.andone.memorip.domain.model.response.PlaceDetail
 import com.andone.memorip.domain.model.response.PlaceImageUploadResponse
 import kotlinx.coroutines.flow.Flow
 import java.io.File
@@ -19,8 +19,10 @@ interface PlaceRepository {
         region2Depth: List<String>? = null,
         sort: List<String>? = null
     ): Flow<PagingData<PlaceListItem>>
+
     suspend fun uploadImage(file: File): Result<PlaceImageUploadResponse>
     suspend fun createPlace(place: PlaceCreateUpdate): Result<PlaceCreated>
+    suspend fun updatePlace(placeId: String, place: PlaceCreateUpdate): Result<PlaceDetail>
     suspend fun deletePlace(placeId: String): Result<Unit>
     suspend fun updatePlaceTrips(
         placeId: String,

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/component/MainBottomBar.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/component/MainBottomBar.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
@@ -29,6 +30,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -65,8 +67,10 @@ fun MainBottomBar(
     onFabClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val navigationBarPadding =
-        WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+    val windowInsetsPadding = WindowInsets.navigationBars.asPaddingValues()
+    val leftPadding = windowInsetsPadding.calculateLeftPadding(LocalLayoutDirection.current)
+    val rightPadding = windowInsetsPadding.calculateRightPadding(LocalLayoutDirection.current)
+    val bottomPadding = windowInsetsPadding.calculateBottomPadding()
 
     AnimatedVisibility(
         visible = visible,
@@ -83,15 +87,20 @@ fun MainBottomBar(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(MemoripHeight.bottomBar + navigationBarPadding)
+                .height(MemoripHeight.bottomBar + bottomPadding)
                 .background(MemoripTheme.colors.transparent),
             contentAlignment = Alignment.TopCenter
         ) {
-            BottomBarSurface(navigationBarPadding)
+            BottomBarSurface(
+                leftPadding = leftPadding,
+                rightPadding = rightPadding,
+                bottomPadding = bottomPadding
+            )
 
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
+                    .padding(start = leftPadding, end = rightPadding)
                     .height(MemoripHeight.bottomBar)
                     .background(MemoripTheme.colors.transparent),
                 horizontalArrangement = Arrangement.SpaceAround,
@@ -104,7 +113,8 @@ fun MainBottomBar(
 
                     val isSelected = tab == currentTab
                     val iconId = if (isSelected) tab.selectedIconId else tab.unselectedIconId
-                    val iconColor = if (isSelected) MemoripTheme.colors.primary else MemoripTheme.colors.gray
+                    val iconColor =
+                        if (isSelected) MemoripTheme.colors.primary else MemoripTheme.colors.gray
 
                     IconButton(
                         onClick = { onTabSelected(tab) },
@@ -147,36 +157,42 @@ private fun BottomBarCenterButton(
 
 @Composable
 private fun BottomBarSurface(
-    navigationBarPadding: Dp,
+    leftPadding: Dp,
+    rightPadding: Dp,
+    bottomPadding: Dp,
     modifier: Modifier = Modifier
 ) {
     val density = LocalDensity.current
+    val leftPx = with(density) { leftPadding.toPx() }
+    val rightPx = with(density) { rightPadding.toPx() }
+    val bottomPx = with(density) { bottomPadding.toPx() }
 
     val firstDpToPx = centerButtonSize.toPx(density)
     val smoothing = (centerButtonSize * 2 / 3).toPx(density)
     val depth = (MemoripHeight.bottomBar - buttonOffset).toPx(density)
 
     val barShape = GenericShape { size, _ ->
-        val width = size.width
-        val height = size.height + navigationBarPadding.toPx(density)
+        val contentWidth = size.width - leftPx - rightPx
+        val centerX = leftPx + contentWidth * 0.5f
+        val height = size.height + bottomPx
 
-        moveTo(width * 0.5f - firstDpToPx, 0f)
-        lineTo(0f, 0f)
-        lineTo(0f, height)
-        lineTo(width, height)
-        lineTo(width, 0f)
-        lineTo(width * 0.5f + firstDpToPx, 0f)
+        moveTo(centerX - firstDpToPx, 0f)
+        lineTo(leftPx, 0f)
+        lineTo(leftPx, height)
+        lineTo(size.width - rightPx, height)
+        lineTo(size.width - rightPx, 0f)
+        lineTo(centerX + firstDpToPx, 0f)
 
         cubicTo(
-            width * 0.5f + smoothing, 0f,
-            width * 0.5f + smoothing, depth,
-            width * 0.5f, depth
+            centerX + smoothing, 0f,
+            centerX + smoothing, depth,
+            centerX, depth
         )
 
         cubicTo(
-            width * 0.5f - smoothing, depth,
-            width * 0.5f - smoothing, 0f,
-            width * 0.5f - firstDpToPx, 0f
+            centerX - smoothing, depth,
+            centerX - smoothing, 0f,
+            centerX - firstDpToPx, 0f
         )
 
         close()

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placecreate/PlaceCreateContainer.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placecreate/PlaceCreateContainer.kt
@@ -45,10 +45,6 @@ private object PlaceCreateContainerDimens {
     const val BAR_WIDTH_FRACTION = 0.4f
 }
 
-private object PlaceCreateNavGraphConstants {
-    const val TOTAL_STEP_SIZE = 3
-}
-
 @Composable
 fun PlaceCreateContainer(
     onNavigateToHome: () -> Unit,
@@ -103,7 +99,8 @@ fun PlaceCreateContainer(
                     viewModel.onAction(PlaceCreateAction.OnTripSelect(trips))
                 },
                 onStepChange = { currentStep = it },
-                currentTrip = uiState.trips
+                selectedTags = uiState.tags,
+                selectedTrips = uiState.trips
             )
         }
     }
@@ -200,7 +197,8 @@ fun PlaceCreateSubStep(
     onTripChange: (List<TripUiModel>) -> Unit,
     onStepChange: (PlaceCreateStep) -> Unit,
     modifier: Modifier = Modifier,
-    currentTrip: List<TripUiModel>? = null
+    selectedTags: List<TagUiModel>? = null,
+    selectedTrips: List<TripUiModel>? = null
 ) {
     when (step) {
         PlaceCreateStep.SelectCategory -> {
@@ -210,6 +208,7 @@ fun PlaceCreateSubStep(
                     onStepChange(PlaceCreateStep.PlaceCreate)
                 },
                 onBackClick = { onStepChange(PlaceCreateStep.PlaceCreate) },
+                selectedTags = selectedTags ?: emptyList(),
                 modifier = modifier
             )
         }
@@ -222,7 +221,7 @@ fun PlaceCreateSubStep(
                 },
                 onBackClick = { onStepChange(PlaceCreateStep.PlaceCreate) },
                 placeId = null,
-                initialSelectedTripIds = currentTrip?.map { it.id },
+                initialSelectedTripIds = selectedTrips?.map { it.id },
                 modifier = modifier
             )
         }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placecreate/PlaceCreateScreen.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placecreate/PlaceCreateScreen.kt
@@ -263,8 +263,8 @@ fun SelectSection(
     onTripClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val locationValue = location?.name
-        ?.ifBlank { null } ?: stringResource(R.string.place_create_location_placeholder)
+    val locationValue = location?.name?.ifBlank { null } ?: location?.address
+    ?: stringResource(R.string.place_create_location_placeholder)
     val tripValue = trips
         .joinToString(stringResource(R.string.place_create_space)) { it.name }
         .ifEmpty { stringResource(R.string.place_create_trip_placeholder) }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placecreate/PlaceCreateScreen.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placecreate/PlaceCreateScreen.kt
@@ -156,7 +156,7 @@ private fun PlaceCreateScreenContent(
             )
 
             SelectSection(
-                category = uiState.category,
+                category = uiState.tags,
                 location = uiState.location,
                 trips = uiState.trips,
                 onCategoryClick = { onAction(PlaceCreateAction.OnCategoryClick) },

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placecreate/PlaceCreateScreen.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placecreate/PlaceCreateScreen.kt
@@ -118,12 +118,6 @@ private fun PlaceCreateScreenContent(
         onAction(PlaceCreateAction.OnImageSelect(uiState.images.first()))
     }
 
-    LaunchedEffect(uiState.images) {
-        if (uiState.images.isEmpty()) {
-            onAction(PlaceCreateAction.OnLastImageRemove)
-        }
-    }
-
     DisposableEffect(Unit) {
         onDispose {
             onAction(PlaceCreateAction.OnScrollPositionChange(scrollState.value))

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placecreate/PlaceCreateViewModel.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placecreate/PlaceCreateViewModel.kt
@@ -106,7 +106,7 @@ class PlaceCreateViewModel @Inject constructor(
     }
 
     fun updateCategory(category: List<TagUiModel>) {
-        _uiState.update { it.copy(category = category) }
+        _uiState.update { it.copy(tags = category) }
     }
 
     fun updateTrip(trips: List<TripUiModel>) {
@@ -152,7 +152,7 @@ class PlaceCreateViewModel @Inject constructor(
                     tripIds = uiStateValue.trips.map { it.id },
                     title = uiStateValue.title,
                     content = uiStateValue.content,
-                    tags = uiStateValue.category.map { it.id },
+                    tags = uiStateValue.tags.map { it.id },
                     latitude = uiStateValue.location.latitude,
                     longitude = uiStateValue.location.longitude,
                     address = Address.from(uiStateValue.location.address),

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placecreate/PlaceCreateViewModel.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placecreate/PlaceCreateViewModel.kt
@@ -75,10 +75,6 @@ class PlaceCreateViewModel @Inject constructor(
                 removeImage(action.imageUri)
             }
 
-            is PlaceCreateAction.OnLastImageRemove -> {
-                _event.trySend(PlaceCreateEvent.NavigateToHome)
-            }
-
             is PlaceCreateAction.OnScrollPositionChange -> {
                 _uiState.update { it.copy(scrollPosition = action.position) }
             }
@@ -119,6 +115,11 @@ class PlaceCreateViewModel @Inject constructor(
 
     private fun removeImage(imageUri: Uri) {
         _uiState.update {
+            if (it.images.size == 1) {
+                snackBarManager.show(SnackBarEvent.IMAGE_COUNT_ERROR)
+                return
+            }
+
             val images = it.images - imageUri
             val selectedImage = if (it.selectedImage == imageUri) {
                 images.firstOrNull()

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placecreate/model/PlaceCreateAction.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placecreate/model/PlaceCreateAction.kt
@@ -22,8 +22,6 @@ sealed interface PlaceCreateAction {
 
     data class OnImagesRemove(val imageUri: Uri) : PlaceCreateAction
 
-    data object OnLastImageRemove : PlaceCreateAction
-
     data class OnScrollPositionChange(val position: Int) : PlaceCreateAction
 
     data class OnPlaceCreate(val context: Context) : PlaceCreateAction

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placecreate/model/PlaceCreateUiState.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placecreate/model/PlaceCreateUiState.kt
@@ -11,7 +11,7 @@ data class PlaceCreateUiState(
     val images: List<Uri> = emptyList(),
     val thumbnailImageRatio: Float = 1f,
     val selectedImage: Uri? = null,
-    val category: List<TagUiModel> = emptyList(),
+    val tags: List<TagUiModel> = emptyList(),
     val location: LocationUiModel? = null,
     val trips: List<TripUiModel> = emptyList(),
     val scrollPosition: Int = 0,

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placedetail/PlaceDetailScreen.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placedetail/PlaceDetailScreen.kt
@@ -119,7 +119,7 @@ fun PlaceDetailScreen(
             }
 
             PlaceDetailEvent.NavigateToSelectTrip -> {
-                onNavigateToTripList()
+                onNavigateToSelectTrip()
             }
 
             PlaceDetailEvent.NavigateToPlaceEdit -> {

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placeedit/PlaceEditContainer.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placeedit/PlaceEditContainer.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.andone.memorip.presentation.screen.placedetail.model.PlaceUiModel
 import com.andone.memorip.presentation.screen.placeedit.model.PlaceEditStep
 import com.andone.memorip.presentation.screen.selectcategory.SelectCategoryScreen
@@ -29,10 +30,12 @@ fun PlaceEditContainer(
     var currentStep by rememberSaveable { mutableStateOf(PlaceEditStep.PlaceEdit) }
 
     val viewModel = hiltViewModel<PlaceEditViewModel, PlaceEditViewModel.Factory>(
+        key = place.hashCode().toString(),
         creationCallback = { factory ->
             factory.create(place)
         }
     )
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     BackHandler(enabled = currentStep != PlaceEditStep.PlaceEdit) {
         currentStep = PlaceEditStep.PlaceEdit
@@ -64,16 +67,6 @@ fun PlaceEditContainer(
 
             }
 
-            PlaceEditStep.SelectCategory -> {
-                SelectCategoryScreen(
-                    onCategorySelect = { tags ->
-                        viewModel.updateTag(tags = tags)
-                        currentStep = PlaceEditStep.PlaceEdit
-                    },
-                    onBackClick = { currentStep = PlaceEditStep.PlaceEdit },
-                )
-            }
-
             PlaceEditStep.SelectTrip -> {
                 SelectTripScreen(
                     onTripSelect = { trips ->
@@ -81,6 +74,18 @@ fun PlaceEditContainer(
                         currentStep = PlaceEditStep.PlaceEdit
                     },
                     onBackClick = { currentStep = PlaceEditStep.PlaceEdit },
+                    initialSelectedTripIds = uiState.trips.map { it.id }
+                )
+            }
+
+            PlaceEditStep.SelectCategory -> {
+                SelectCategoryScreen(
+                    onCategorySelect = { tags ->
+                        viewModel.updateTag(tags = tags)
+                        currentStep = PlaceEditStep.PlaceEdit
+                    },
+                    onBackClick = { currentStep = PlaceEditStep.PlaceEdit },
+                    selectedTags = uiState.tags
                 )
             }
         }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placeedit/PlaceEditScreen.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placeedit/PlaceEditScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -46,7 +47,7 @@ fun PlaceEditScreen(
     viewModel: PlaceEditViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    val initUiState by viewModel.initUiState.collectAsStateWithLifecycle()
+    val isUpdateEnabled by viewModel.isUpdateEnabled.collectAsStateWithLifecycle()
 
     viewModel.event.collectWithLifecycle { event ->
         when (event) {
@@ -60,7 +61,7 @@ fun PlaceEditScreen(
     Box(modifier = modifier.fillMaxSize()) {
         PlaceEditScreenContent(
             uiState = uiState,
-            initUiState = initUiState,
+            isUpdateEnabled = isUpdateEnabled,
             onAction = viewModel::onAction
         )
 
@@ -74,26 +75,16 @@ fun PlaceEditScreen(
 @Composable
 private fun PlaceEditScreenContent(
     uiState: PlaceEditUiState,
-    initUiState: PlaceEditUiState,
+    isUpdateEnabled: Boolean,
     onAction: (PlaceEditAction) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val scrollState = rememberScrollState(uiState.scrollPosition)
+    val context = LocalContext.current
 
-    val placeEditEnable = (uiState.images.isNotEmpty() &&
-            uiState.location != null &&
-            uiState.title.isNotBlank() &&
-            uiState.trips.isNotEmpty()) &&
-            uiState != initUiState
+    val scrollState = rememberScrollState(uiState.scrollPosition)
 
     LaunchedEffect(Unit) {
         onAction(PlaceEditAction.OnImageSelect(uiState.images.first()))
-    }
-
-    LaunchedEffect(uiState.images) {
-        if (uiState.images.isEmpty()) {
-            onAction(PlaceEditAction.OnLastImageRemove)
-        }
     }
 
     DisposableEffect(Unit) {
@@ -112,8 +103,8 @@ private fun PlaceEditScreenContent(
         bottomBar = {
             PlaceEditBottomBar(
                 value = stringResource(R.string.place_edit_title),
-                onClick = { },
-                enabled = placeEditEnable
+                onClick = { onAction(PlaceEditAction.OnPlaceUpdate(context)) },
+                enabled = isUpdateEnabled
             )
         },
         contentWindowInsets = WindowInsets()
@@ -163,7 +154,7 @@ private fun PlaceEditScreenPreview() {
     MemoripTheme {
         PlaceEditScreenContent(
             uiState = PlaceEditUiState(),
-            initUiState = PlaceEditUiState(),
+            isUpdateEnabled = true,
             onAction = {}
         )
     }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placeedit/PlaceEditViewModel.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placeedit/PlaceEditViewModel.kt
@@ -14,6 +14,7 @@ import com.andone.memorip.presentation.screen.placeedit.model.PlaceEditAction
 import com.andone.memorip.presentation.screen.placeedit.model.PlaceEditEvent
 import com.andone.memorip.presentation.screen.placeedit.model.toUiState
 import com.andone.memorip.presentation.util.BitmapCropUtil.getAspectRatioFromUrl
+import com.andone.memorip.presentation.util.snackbar.SnackBarEvent
 import com.andone.memorip.presentation.util.snackbar.SnackBarManager
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -114,6 +115,7 @@ class PlaceEditViewModel @AssistedInject constructor(
     private fun removeImage(imageUri: Uri) {
         _uiState.update {
             if (it.images.size == 1) {
+                snackBarManager.show(SnackBarEvent.IMAGE_COUNT_ERROR)
                 return
             }
 
@@ -161,6 +163,7 @@ class PlaceEditViewModel @AssistedInject constructor(
             ).onSuccess {
                 _event.trySend(PlaceEditEvent.NavigateBack)
             }.onFailure {
+                snackBarManager.show(SnackBarEvent.NETWORK_ERROR)
             }
             _uiState.update { it.copy(isLoading = false) }
         }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placeedit/PlaceEditViewModel.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placeedit/PlaceEditViewModel.kt
@@ -1,17 +1,19 @@
 package com.andone.memorip.presentation.screen.placeedit
 
+import android.content.Context
 import android.net.Uri
-import androidx.core.net.toUri
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.andone.memorip.domain.model.request.Address
+import com.andone.memorip.domain.model.request.PlaceCreateUpdate
 import com.andone.memorip.domain.repository.PlaceRepository
-import com.andone.memorip.presentation.model.LocationUiModel
 import com.andone.memorip.presentation.model.TagUiModel
 import com.andone.memorip.presentation.model.TripUiModel
-import com.andone.memorip.presentation.model.toUiModel
 import com.andone.memorip.presentation.screen.placedetail.model.PlaceUiModel
 import com.andone.memorip.presentation.screen.placeedit.model.PlaceEditAction
 import com.andone.memorip.presentation.screen.placeedit.model.PlaceEditEvent
-import com.andone.memorip.presentation.screen.placeedit.model.PlaceEditUiState
+import com.andone.memorip.presentation.screen.placeedit.model.toUiState
+import com.andone.memorip.presentation.util.BitmapCropUtil.getAspectRatioFromUrl
 import com.andone.memorip.presentation.util.snackbar.SnackBarManager
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -20,9 +22,13 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.BUFFERED
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 
 @HiltViewModel(assistedFactory = PlaceEditViewModel.Factory::class)
 class PlaceEditViewModel @AssistedInject constructor(
@@ -31,31 +37,27 @@ class PlaceEditViewModel @AssistedInject constructor(
     private val snackBarManager: SnackBarManager
 ) : ViewModel() {
 
-    private val _uiState = MutableStateFlow(
-        PlaceEditUiState(
-            id = place.id,
-            title = place.title,
-            content = place.content,
-            images = place.imageUrls.map { it.toUri() },
-            location = LocationUiModel(
-                name = place.locationName,
-                address = place.locationName,
-                roadAddress = place.locationName,
-                latitude = place.latitude,
-                longitude = place.longitude
-            ),
-            trips = place.trips.map { it.toUiModel() },
-            tags = place.tags,
-            isPublic = place.isPublic,
-            isLoading = false
-        )
-    )
+    private val _uiState = MutableStateFlow(place.toUiState())
     val uiState = _uiState.asStateFlow()
 
     private val _event = Channel<PlaceEditEvent>(capacity = BUFFERED)
     val event = _event.receiveAsFlow()
 
-    val initUiState = _uiState
+    val isUpdateEnabled = _uiState.map {
+        val isValueRequired = it.images.isNotEmpty() &&
+                it.location != null &&
+                it.title.isNotBlank() &&
+                it.trips.isNotEmpty()
+
+        val isChanged = it.copy(selectedImage = null, scrollPosition = 0, isLoading = false) !=
+                place.toUiState().copy(selectedImage = null, scrollPosition = 0, isLoading = false)
+
+        isValueRequired && isChanged
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000),
+        initialValue = false
+    )
 
     fun onAction(action: PlaceEditAction) {
         when (action) {
@@ -91,16 +93,12 @@ class PlaceEditViewModel @AssistedInject constructor(
                 removeImage(action.imageUri)
             }
 
-            PlaceEditAction.OnLastImageRemove -> {
-                _event.trySend(PlaceEditEvent.NavigateBack)
-            }
-
             is PlaceEditAction.OnScrollPositionChange -> {
                 _uiState.update { it.copy(scrollPosition = action.position) }
             }
 
-            PlaceEditAction.OnPlaceUpdate -> {
-                updatePlace()
+            is PlaceEditAction.OnPlaceUpdate -> {
+                updatePlace(action.context)
             }
 
             is PlaceEditAction.OnSnackBarShow -> {
@@ -115,6 +113,10 @@ class PlaceEditViewModel @AssistedInject constructor(
 
     private fun removeImage(imageUri: Uri) {
         _uiState.update {
+            if (it.images.size == 1) {
+                return
+            }
+
             val imageUrls = it.images - imageUri
             val selectedImage = if (it.selectedImage == imageUri) {
                 imageUrls.firstOrNull()
@@ -129,8 +131,39 @@ class PlaceEditViewModel @AssistedInject constructor(
         }
     }
 
-    private fun updatePlace() {
+    private fun updatePlace(context: Context) {
+        val uiStateValue = _uiState.value
+        if (uiStateValue.images.isEmpty()
+            || uiStateValue.location == null
+            || uiStateValue.title.isBlank()
+            || uiStateValue.trips.isEmpty()
+        ) return
 
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
+            placeRepository.updatePlace(
+                placeId = uiStateValue.id,
+                place = PlaceCreateUpdate(
+                    tripIds = uiStateValue.trips.map { it.id },
+                    title = uiStateValue.title,
+                    content = uiStateValue.content,
+                    tags = uiStateValue.tags.map { it.id },
+                    latitude = uiStateValue.location.latitude,
+                    longitude = uiStateValue.location.longitude,
+                    address = Address.from(uiStateValue.location.address),
+                    imageUrls = uiStateValue.images.map { it.toString() },
+                    thumbnailImageRatio = getAspectRatioFromUrl(
+                        context = context,
+                        imageUrl = uiStateValue.images.first().toString()
+                    ),
+                    isPublic = uiStateValue.isPublic
+                )
+            ).onSuccess {
+                _event.trySend(PlaceEditEvent.NavigateBack)
+            }.onFailure {
+            }
+            _uiState.update { it.copy(isLoading = false) }
+        }
     }
 
     fun updateTrip(trips: List<TripUiModel>) {

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placeedit/model/PlaceEditAction.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placeedit/model/PlaceEditAction.kt
@@ -1,5 +1,6 @@
 package com.andone.memorip.presentation.screen.placeedit.model
 
+import android.content.Context
 import android.net.Uri
 
 sealed interface PlaceEditAction {
@@ -20,11 +21,9 @@ sealed interface PlaceEditAction {
 
     data class OnImagesRemove(val imageUri: Uri) : PlaceEditAction
 
-    data object OnLastImageRemove : PlaceEditAction
-
     data class OnScrollPositionChange(val position: Int) : PlaceEditAction
 
-    data object OnPlaceUpdate : PlaceEditAction
+    data class OnPlaceUpdate(val context: Context) : PlaceEditAction
 
     data class OnSnackBarShow(val message: String) : PlaceEditAction
 

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placeedit/model/PlaceEditUiState.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placeedit/model/PlaceEditUiState.kt
@@ -1,9 +1,12 @@
 package com.andone.memorip.presentation.screen.placeedit.model
 
 import android.net.Uri
+import androidx.core.net.toUri
 import com.andone.memorip.presentation.model.LocationUiModel
 import com.andone.memorip.presentation.model.TagUiModel
 import com.andone.memorip.presentation.model.TripUiModel
+import com.andone.memorip.presentation.model.toUiModel
+import com.andone.memorip.presentation.screen.placedetail.model.PlaceUiModel
 
 data class PlaceEditUiState(
     val id: String = "",
@@ -18,3 +21,25 @@ data class PlaceEditUiState(
     val isPublic: Boolean = false,
     val isLoading: Boolean = true
 )
+
+fun PlaceUiModel.toUiState(): PlaceEditUiState {
+    return PlaceEditUiState(
+        id = id,
+        title = title,
+        content = content,
+        images = imageUrls.map { it.toUri() },
+        selectedImage = null,
+        location = LocationUiModel(
+            name = locationName,
+            address = locationName,
+            roadAddress = locationName,
+            latitude = latitude,
+            longitude = longitude
+        ),
+        trips = trips.map { it.toUiModel() },
+        tags = tags,
+        scrollPosition = 0,
+        isPublic = isPublic,
+        isLoading = false
+    )
+}

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/selectcategory/SelectCategoryScreen.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/selectcategory/SelectCategoryScreen.kt
@@ -118,7 +118,6 @@ private fun SelectCategoryContent(
         modifier = modifier,
         topBar = {
             SelectCategoryTopBar(
-                checkEnabled = checkedCategories.isNotEmpty(),
                 onConfirmClick = { onAction(SelectCategoryAction.OnConfirmClick) },
                 onBackClick = { onAction(SelectCategoryAction.OnBackClick) }
             )

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/selectcategory/SelectCategoryScreen.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/selectcategory/SelectCategoryScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -41,6 +42,7 @@ fun SelectCategoryScreen(
     onCategorySelect: (List<TagUiModel>) -> Unit,
     onBackClick: () -> Unit,
     modifier: Modifier = Modifier,
+    selectedTags: List<TagUiModel> = emptyList(),
     viewModel: SelectCategoryViewModel = hiltViewModel()
 ) {
     val context = LocalContext.current
@@ -75,6 +77,10 @@ fun SelectCategoryScreen(
                 )
             }
         }
+    }
+
+    LaunchedEffect(selectedTags) {
+        viewModel.onAction(SelectCategoryAction.OnInitialTags(selectedTags))
     }
 
     SelectCategoryContent(
@@ -167,6 +173,7 @@ private fun SelectCategoryContent(
 private fun SelectCategoryPreview() {
     MemoripTheme {
         SelectCategoryScreen(
+            selectedTags = emptyList(),
             onCategorySelect = {},
             onBackClick = {}
         )

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/selectcategory/SelectCategoryViewModel.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/selectcategory/SelectCategoryViewModel.kt
@@ -49,6 +49,10 @@ class SelectCategoryViewModel @Inject constructor(
 
     fun onAction(action: SelectCategoryAction) {
         when (action) {
+            is SelectCategoryAction.OnInitialTags -> {
+                _uiState.update { it.copy(checkedCategories = action.tags) }
+            }
+
             SelectCategoryAction.OnBackClick -> {
                 _event.trySend(element = SelectCategoryEvent.NavigateBack)
             }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/selectcategory/component/SelectCategoryTopBar.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/selectcategory/component/SelectCategoryTopBar.kt
@@ -18,7 +18,6 @@ import com.andone.memorip.presentation.theme.MemoripTheme
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SelectCategoryTopBar(
-    checkEnabled: Boolean,
     onConfirmClick: () -> Unit,
     onBackClick: () -> Unit
 ) {
@@ -38,18 +37,11 @@ fun SelectCategoryTopBar(
             }
         },
         actions = {
-            IconButton(
-                onClick = onConfirmClick,
-                enabled = checkEnabled,
-            ) {
+            IconButton(onClick = onConfirmClick) {
                 Icon(
                     imageVector = ImageVector.vectorResource(R.drawable.ic_check),
                     contentDescription = stringResource(R.string.select_category_confirm_button_description),
-                    tint = if (checkEnabled) {
-                        MemoripTheme.colors.primary
-                    } else {
-                        MemoripTheme.colors.lightGray
-                    }
+                    tint = MemoripTheme.colors.primary
                 )
             }
         },

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/selectcategory/model/SelectCategoryAction.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/selectcategory/model/SelectCategoryAction.kt
@@ -5,6 +5,8 @@ import com.andone.memorip.presentation.model.TagUiModel
 
 sealed interface SelectCategoryAction {
 
+    data class OnInitialTags(val tags: List<TagUiModel>) : SelectCategoryAction
+
     data class OnCategoryItemClick(
         val tagUiModel: TagUiModel,
         val checked: Boolean

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/selectlocation/SelectLocationScreen.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/selectlocation/SelectLocationScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -93,6 +94,8 @@ private fun SelectLocationContent(
     onAction: (SelectLocationAction) -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val context = LocalContext.current
+
     val cameraPositionState = uiState.location?.let {
         rememberCameraPositionState {
             position = CameraPosition(LatLng(it.latitude, it.longitude), CAMERA_POSITION_ZOOM)
@@ -100,7 +103,6 @@ private fun SelectLocationContent(
     } ?: run {
         rememberCameraPositionState()
     }
-
     var searchBarExpanded by rememberSaveable { mutableStateOf(false) }
 
     fun cameraPositionMove(latLng: LatLng) {
@@ -194,7 +196,9 @@ private fun SelectLocationContent(
 
         LocationSelectionButton(
             onClick = {
-                uiState.location?.let { onAction(SelectLocationAction.OnLocationSelect(it)) }
+                uiState.location?.let { location ->
+                    onAction(SelectLocationAction.OnLocationSelect(context, location))
+                }
             },
             enabled = uiState.location != null,
             modifier = Modifier

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/selectlocation/SelectLocationViewModel.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/selectlocation/SelectLocationViewModel.kt
@@ -1,5 +1,9 @@
 package com.andone.memorip.presentation.screen.selectlocation
 
+import android.content.Context
+import android.location.Address
+import android.location.Geocoder
+import android.os.Build
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
@@ -13,6 +17,7 @@ import com.andone.memorip.presentation.screen.selectlocation.model.SelectLocatio
 import com.andone.memorip.presentation.screen.selectlocation.model.SelectLocationEvent
 import com.andone.memorip.presentation.screen.selectlocation.model.SelectLocationUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.channels.Channel
@@ -27,7 +32,13 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import java.util.Locale
+import java.util.UUID
 import javax.inject.Inject
+import kotlin.coroutines.resume
 
 private object SelectLocationViewModelConstants {
     const val TIMEOUT_MILLS = 500L
@@ -84,12 +95,65 @@ class SelectLocationViewModel @Inject constructor(
             }
 
             is SelectLocationAction.OnLocationSelect -> {
-                _event.trySend(SelectLocationEvent.SelectLocation(action.location))
+                viewModelScope.launch {
+                    val selectedLocation = if (action.location.address.isEmpty()) {
+                        getAddressFromLatLng(
+                            action.context,
+                            action.location.latitude,
+                            action.location.longitude
+                        )
+                    } else {
+                        action.location
+                    }
+
+                    selectedLocation?.let { location ->
+                        _event.trySend(SelectLocationEvent.SelectLocation(location))
+                    }
+                }
             }
         }
     }
 
     private fun changeQuery(query: String) {
         _uiState.update { it.copy(query = query) }
+    }
+
+    private suspend fun getAddressFromLatLng(
+        context: Context,
+        latitude: Double,
+        longitude: Double
+    ): LocationUiModel = withContext(Dispatchers.IO) {
+        val geocoder = Geocoder(context, Locale.KOREA)
+        return@withContext suspendCancellableCoroutine { continuation ->
+            try {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    geocoder.getFromLocation(latitude, longitude, 1) { addresses ->
+                        val firstAddress = addresses.firstOrNull() ?: error("Address not found")
+                        continuation.resume(firstAddress.toLocationUiModel())
+                    }
+                } else {
+                    @Suppress("DEPRECATION")
+                    val addresses = geocoder.getFromLocation(latitude, longitude, 1)
+                    val firstAddress = addresses?.firstOrNull() ?: error("Address not found")
+                    continuation.resume(firstAddress.toLocationUiModel())
+                }
+            } catch (_: Exception) {
+                continuation.resume(
+                    LocationUiModel(
+                        latitude = latitude,
+                        longitude = longitude
+                    )
+                )
+            }
+        }
+    }
+
+    private fun Address.toLocationUiModel(): LocationUiModel {
+        return LocationUiModel(
+            id = UUID.randomUUID().toString(),
+            address = getAddressLine(0),
+            latitude = latitude,
+            longitude = longitude
+        )
     }
 }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/selectlocation/model/SelectLocationAction.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/selectlocation/model/SelectLocationAction.kt
@@ -1,5 +1,6 @@
 package com.andone.memorip.presentation.screen.selectlocation.model
 
+import android.content.Context
 import com.andone.memorip.presentation.model.LocationUiModel
 import com.naver.maps.geometry.LatLng
 
@@ -11,5 +12,8 @@ sealed interface SelectLocationAction {
 
     data class OnMapClick(val location: LatLng) : SelectLocationAction
 
-    data class OnLocationSelect(val location: LocationUiModel) : SelectLocationAction
+    data class OnLocationSelect(
+        val context: Context,
+        val location: LocationUiModel
+    ) : SelectLocationAction
 }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/util/BitmapCropUtil.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/util/BitmapCropUtil.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.positionChanged
 import androidx.core.graphics.createBitmap
+import androidx.core.net.toUri
 import androidx.exifinterface.media.ExifInterface
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -228,5 +229,25 @@ object BitmapCropUtil {
         }
 
         Uri.fromFile(file)
+    }
+
+    /** 이미지의 비율 계산 **/
+    suspend fun getAspectRatioFromUrl(
+        context: Context,
+        imageUrl: String
+    ): Float = withContext(Dispatchers.IO) {
+        runCatching {
+            val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+
+            context.contentResolver.openInputStream(imageUrl.toUri()).use { stream ->
+                BitmapFactory.decodeStream(stream, null, options)
+            }
+
+            if (options.outHeight != 0) {
+                options.outWidth.toFloat() / options.outHeight.toFloat()
+            } else {
+                1f
+            }
+        }.getOrDefault(1f)
     }
 }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/util/snackbar/SnackBarError.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/util/snackbar/SnackBarError.kt
@@ -24,6 +24,7 @@ enum class SnackBarEvent(
     // UI Error
     PLAN_DAYS_VALIDATION_ERROR(messageResId = R.string.snackbar_plan_days_validation_error),
     PLAN_INVALID_ERROR(messageResId = R.string.snackbar_plan_invalid_error),
+    IMAGE_COUNT_ERROR(messageResId = R.string.snackbar_image_count_error),
 
     // 성공
     SUCCESS(messageResId = R.string.snackbar_success)

--- a/client/presentation/src/main/res/values/strings.xml
+++ b/client/presentation/src/main/res/values/strings.xml
@@ -171,6 +171,7 @@
     <string name="snackbar_unknown_error">오류가 발생했습니다. 다시 시도해주세요</string>
     <string name="snackbar_plan_days_validation_error">날짜는 최대 1달까지 지정 가능합니다</string>
     <string name="snackbar_plan_invalid_error">다른 계획과 중복 배치는 지원하지 않습니다</string>
+    <string name="snackbar_image_count_error">이미지는 최소 1개 이상 있어야 합니다.</string>
     <string name="snackbar_success">성공적으로 완료되었습니다</string>
 
     <!-- UserScreen -->

--- a/server/src/main/kotlin/com/andone/memorip/feature/place/service/PlaceService.kt
+++ b/server/src/main/kotlin/com/andone/memorip/feature/place/service/PlaceService.kt
@@ -124,7 +124,7 @@ class PlaceService(
             if (tags.size != request.tags.size) {
                 throw BusinessException(code = CommonExceptionCode.TAG_NOT_FOUND)
             }
-            
+
             val placeTags = tags.map { tag ->
                 PlaceTag.create(place = savedPlace, tag = tag)
             }
@@ -182,12 +182,13 @@ class PlaceService(
 
         // 태그 업데이트 (전체 치환)
         placeTagRepository.deleteByPlaceId(placeId)
+        placeTagRepository.flush()
         if (!request.tags.isNullOrEmpty()) {
             val tags = tagRepository.findAllById(request.tags)
             if (tags.size != request.tags.size) {
                 throw BusinessException(code = CommonExceptionCode.TAG_NOT_FOUND)
             }
-            
+
             val placeTags = tags.map { tag ->
                 PlaceTag.create(place = place, tag = tag)
             }


### PR DESCRIPTION
## 📝 변경 사항
장소 수정 기능의 API 연결, 장소 추가 시 위·경도를 이용한 주소 변환 로직 추가, 바텀 바의 가로모드 대응을 구현했습니다.

## 🎯 작업 내용

### 장소 수정
- 장소 수정 화면과 API를 연결하여 수정 기능 완성
- 태그 선택 화면에서 초기 태그 설정 동작 추가 (수정 시 기존 태그 반영)

### 장소 추가
- 위도·경도 좌표로 주소를 변환하는 로직 추가 (역지오코딩)
- 장소 추가 화면의 UI와 API 연결 완료
- 장소 추가 화면에서 위치 표시 UI 수정
- 이미지 비율 계산 로직을 Util로 분리
- 장소 추가 화면에 이미지 최소 개수 제한 적용
- 스낵 바 메시지 추가 (성공/실패 피드백)

### 바텀 바
- 바텀 바에 가로모드 대응 구현

### 코드 정리
- `group`에서 `trip`으로 명칭 통일
- 네비게이션 관련 네이밍 정리
- 변수명 수정

## 🔗 관련 이슈
Closes #188

## 💬 리뷰어에게
- 역지오코딩(위·경도 → 주소 변환) 로직 및 오류 처리를 확인해 주세요.
- 장소 수정 API 연결 부분과 태그 초기 설정 동작을 테스트해 주세요.
- 바텀 바 가로모드 대응이 다양한 기기에서 올바르게 동작하는지 확인해 주세요.