### PR TITLE
[Feature] 여행 상세 화면 추가 UI/UX 개선

### DIFF
--- a/client/presentation/src/main/java/com/andone/memorip/navigation/MemoripNav.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/navigation/MemoripNav.kt
@@ -81,7 +81,10 @@ fun MemoripNav(
                 onBackClick = navigator::popBackStack
             )
 
-            tripDetail(onNavigateBack = navigator::popBackStack)
+            tripDetail(
+                onNavigateBack = navigator::popBackStack,
+                onNavigateToPlaceDetail = navigator::navigateToPlaceDetail
+            )
 
             placeDetail(
                 onNavigateBack = navigator::popBackStack,

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/component/map/ClusterMarker.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/component/map/ClusterMarker.kt
@@ -16,8 +16,10 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.andone.memorip.presentation.R
 import com.andone.memorip.presentation.component.map.ClusterMarkerDimen.BorderWidth
 import com.andone.memorip.presentation.component.map.ClusterMarkerDimen.CornerRadius
 import com.andone.memorip.presentation.component.map.ClusterMarkerDimen.InnerSize
@@ -29,6 +31,10 @@ private object ClusterMarkerDimen {
     val InnerSize = 48.dp
     val BorderWidth: Dp = MemoripLineWidth.Small
     val CornerRadius: Dp = 6.dp
+}
+
+private object ClusterMarkerConstant {
+    const val MAX_DISPLAY_COUNT = 99
 }
 
 @Composable
@@ -66,7 +72,11 @@ fun ClusterMarker(
                 contentAlignment = Alignment.Center
             ) {
                 Text(
-                    text = if (count > 99) "99+" else count.toString(),
+                    text = if (count > ClusterMarkerConstant.MAX_DISPLAY_COUNT) {
+                        stringResource(R.string.map_cluster_marker_max_count)
+                    } else {
+                        count.toString()
+                    },
                     color = MemoripTheme.colors.background,
                     style = MemoripTheme.typography.labelMedium14
                 )

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/component/map/ClusterMarker.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/component/map/ClusterMarker.kt
@@ -1,7 +1,10 @@
 package com.andone.memorip.presentation.component.map
 
+import android.graphics.Bitmap
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
@@ -10,6 +13,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -17,38 +22,55 @@ import com.andone.memorip.presentation.component.map.ClusterMarkerDimen.BorderWi
 import com.andone.memorip.presentation.component.map.ClusterMarkerDimen.CornerRadius
 import com.andone.memorip.presentation.component.map.ClusterMarkerDimen.InnerSize
 import com.andone.memorip.presentation.theme.MemoripLineWidth
+import com.andone.memorip.presentation.theme.MemoripPadding
 import com.andone.memorip.presentation.theme.MemoripTheme
 
 private object ClusterMarkerDimen {
     val InnerSize = 48.dp
-    val BorderWidth: Dp = MemoripLineWidth.Medium
+    val BorderWidth: Dp = MemoripLineWidth.Small
     val CornerRadius: Dp = 6.dp
 }
 
 @Composable
 fun ClusterMarker(
     count: Int,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    imageBitmap: Bitmap? = null
 ) {
     Box(
         modifier = modifier
             .size(size = InnerSize + BorderWidth * 2)
             .clip(shape = RoundedCornerShape(size = CornerRadius))
-            .background(MemoripTheme.colors.primary),
-        contentAlignment = Alignment.Center
+            .background(MemoripTheme.colors.background)
     ) {
         Box(
             modifier = Modifier
                 .size(InnerSize)
                 .clip(shape = RoundedCornerShape(size = CornerRadius - BorderWidth))
-                .background(Color.White),
-            contentAlignment = Alignment.Center
+                .background(MemoripTheme.colors.primaryContainer)
+                .align(Alignment.Center)
         ) {
-            Text(
-                text = if (count > 99) "99+" else count.toString(),
-                color = MemoripTheme.colors.primary,
-                style = MemoripTheme.typography.labelMedium14
-            )
+            imageBitmap?.let { bitmap ->
+                Image(
+                    bitmap = bitmap.asImageBitmap(),
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    alignment = Alignment.Center,
+                    modifier = Modifier.matchParentSize()
+                )
+            }
+            Box(
+                modifier = Modifier
+                    .align(Alignment.BottomStart)
+                    .padding(all = MemoripPadding.PaddingXXXSmall),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = if (count > 99) "99+" else count.toString(),
+                    color = MemoripTheme.colors.background,
+                    style = MemoripTheme.typography.labelMedium14
+                )
+            }
         }
     }
 }
@@ -57,6 +79,6 @@ fun ClusterMarker(
 @Composable
 private fun ClusterMarkerPreview() {
     MemoripTheme {
-        ClusterMarker(count = 5)
+        ClusterMarker(count = 100, imageBitmap = null)
     }
 }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/component/map/ImageMarker.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/component/map/ImageMarker.kt
@@ -28,7 +28,7 @@ import com.andone.memorip.presentation.theme.MemoripTheme
 
 private object ImageMarkerDimen {
     val ImageSize: Dp = 48.dp
-    val BorderWidth: Dp = MemoripLineWidth.Medium
+    val BorderWidth: Dp = MemoripLineWidth.Small
     val CornerRadius: Dp = 6.dp
 }
 
@@ -36,7 +36,7 @@ private object ImageMarkerDimen {
 fun ImageMarker(
     imageBitmap: Bitmap,
     modifier: Modifier = Modifier,
-    borderColor: Color = MemoripTheme.colors.primaryContainer
+    borderColor: Color = MemoripTheme.colors.primary
 ) {
     Box(
         modifier = modifier

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/TripDetailNavGraph.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/TripDetailNavGraph.kt
@@ -12,12 +12,14 @@ fun NavBackStack<NavKey>.navigateToTripDetail(tripId: String) {
 
 fun EntryProviderScope<NavKey>.tripDetail(
     onNavigateBack: () -> Unit,
+    onNavigateToPlaceDetail: (String) -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     entry<TripDetail> { route ->
         TripDetailScreen(
             route = route,
             onBackClick = onNavigateBack,
+            onNavigateToPlaceDetail = onNavigateToPlaceDetail,
             modifier = modifier
         )
     }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/TripDetailScreen.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/TripDetailScreen.kt
@@ -39,6 +39,7 @@ import com.naver.maps.geometry.LatLng
 fun TripDetailScreen(
     route: TripDetail,
     onBackClick: () -> Unit,
+    onNavigateToPlaceDetail: (String) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: TripDetailViewModel = hiltViewModel<TripDetailViewModel, TripDetailViewModel.Factory>(
         creationCallback = { factory -> factory.create(route) }
@@ -59,6 +60,7 @@ fun TripDetailScreen(
     viewModel.event.collectWithLifecycle { event ->
         when (event) {
             TripDetailEvent.NavigateBack -> onBackClick()
+            is TripDetailEvent.NavigateToPlaceDetail -> onNavigateToPlaceDetail(event.id)
         }
     }
 

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/TripDetailScreen.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/TripDetailScreen.kt
@@ -26,7 +26,7 @@ import com.andone.memorip.presentation.component.map.rememberBitmapMarkerLoader
 import com.andone.memorip.presentation.model.Place
 import com.andone.memorip.presentation.model.TripUiModel
 import com.andone.memorip.presentation.screen.tripdetail.component.TripDetailTopBar
-import com.andone.memorip.presentation.screen.tripdetail.component.MapTab
+import com.andone.memorip.presentation.screen.tripdetail.component.TripMap
 import com.andone.memorip.presentation.screen.tripdetail.model.PlaceViewMode
 import com.andone.memorip.presentation.screen.tripdetail.model.TripDetailAction
 import com.andone.memorip.presentation.screen.tripdetail.model.TripDetailEvent
@@ -50,8 +50,12 @@ fun TripDetailScreen(
     val placesPagingItems = viewModel.placesPagingFlow.collectAsLazyPagingItems()
     val clusteredItems by viewModel.clusteredItemsStateFlow.collectAsStateWithLifecycle()
     var places by remember { mutableStateOf<List<Place>>(emptyList()) }
+    var mapLoaded by rememberSaveable { mutableStateOf(false) }
     val hasMorePages = (placesPagingItems.loadState.append as? LoadState.NotLoading)
         ?.endOfPaginationReached == false
+    val markerImages = rememberBitmapMarkerLoader(
+        imageUrls = places.map { it.thumbnailImage.url }
+    )
 
     LaunchedEffect(placesPagingItems) {
         snapshotFlow { placesPagingItems.itemSnapshotList.items }
@@ -71,11 +75,14 @@ fun TripDetailScreen(
         tripName = uiState.tripName,
         places = places,
         clusteredItems = clusteredItems,
+        markerImages = markerImages,
         mapSelectedPlace = uiState.mapSelectedPlace,
         mapBottomSheetContent = uiState.mapBottomSheetContent,
         tripInfo = uiState.tripInfo,
         viewMode = uiState.placeViewMode,
         hasMorePages = hasMorePages,
+        mapLoaded = mapLoaded,
+        onMapLoaded = { mapLoaded = true },
         onAction = viewModel::onAction,
         modifier = modifier
     )
@@ -86,19 +93,18 @@ private fun TripDetailScreenContent(
     tripName: String,
     places: List<Place>,
     clusteredItems: List<MapClusterManager.ClusterItem>,
+    markerImages: Map<String, android.graphics.Bitmap>,
     mapSelectedPlace: Place?,
     mapBottomSheetContent: MapBottomSheetStep,
     tripInfo: TripUiModel?,
     viewMode: PlaceViewMode,
     hasMorePages: Boolean,
+    mapLoaded: Boolean,
+    onMapLoaded: () -> Unit,
     onAction: (TripDetailAction) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    var mapLoaded by rememberSaveable { mutableStateOf(false) }
     var isBottomSheetExpanded by remember { mutableStateOf(false) }
-    val markerImages = rememberBitmapMarkerLoader(
-        imageUrls = places.map { it.thumbnailImage.url }
-    )
 
     Scaffold(
         topBar = {
@@ -111,13 +117,13 @@ private fun TripDetailScreenContent(
         contentWindowInsets = WindowInsets.navigationBars,
         modifier = modifier
     ) { innerPadding ->
-        MapTab(
+        TripMap(
             places = places,
             clusteredItems = clusteredItems,
             markerImages = markerImages,
             mapBottomSheetContent = mapBottomSheetContent,
             mapLoaded = mapLoaded,
-            onMapLoaded = { mapLoaded = true },
+            onMapLoaded = onMapLoaded,
             onAction = onAction,
             mapSelectedPlace = mapSelectedPlace,
             tripName = tripInfo?.name,
@@ -158,6 +164,7 @@ private fun TripDetailScreenContentPreview() {
             tripName = "서울대공원 주암 나들이",
             places = DummyData.places,
             clusteredItems = clusteredItems,
+            markerImages = emptyMap(),
             mapSelectedPlace = null,
             mapBottomSheetContent = MapBottomSheetStep.PlaceList,
             tripInfo = TripUiModel(
@@ -169,6 +176,8 @@ private fun TripDetailScreenContentPreview() {
             ),
             viewMode = PlaceViewMode.LIST,
             hasMorePages = false,
+            mapLoaded = true,
+            onMapLoaded = {},
             onAction = {}
         )
     }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/TripDetailScreen.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/TripDetailScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.paging.LoadState
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.andone.memorip.navigation.TripDetail
 import com.andone.memorip.presentation.component.map.MapClusterManager
@@ -49,6 +50,8 @@ fun TripDetailScreen(
     val placesPagingItems = viewModel.placesPagingFlow.collectAsLazyPagingItems()
     val clusteredItems by viewModel.clusteredItemsStateFlow.collectAsStateWithLifecycle()
     var places by remember { mutableStateOf<List<Place>>(emptyList()) }
+    val hasMorePages = (placesPagingItems.loadState.append as? LoadState.NotLoading)
+        ?.endOfPaginationReached == false
 
     LaunchedEffect(placesPagingItems) {
         snapshotFlow { placesPagingItems.itemSnapshotList.items }
@@ -72,6 +75,7 @@ fun TripDetailScreen(
         mapBottomSheetContent = uiState.mapBottomSheetContent,
         tripInfo = uiState.tripInfo,
         viewMode = uiState.placeViewMode,
+        hasMorePages = hasMorePages,
         onAction = viewModel::onAction,
         modifier = modifier
     )
@@ -86,6 +90,7 @@ private fun TripDetailScreenContent(
     mapBottomSheetContent: MapBottomSheetStep,
     tripInfo: TripUiModel?,
     viewMode: PlaceViewMode,
+    hasMorePages: Boolean,
     onAction: (TripDetailAction) -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -119,6 +124,7 @@ private fun TripDetailScreenContent(
             startDate = tripInfo?.startDate,
             endDate = tripInfo?.endDate,
             viewMode = viewMode,
+            hasMorePages = hasMorePages,
             onBottomSheetExpandedChange = { isExpanded ->
                 isBottomSheetExpanded = isExpanded
             },
@@ -162,6 +168,7 @@ private fun TripDetailScreenContentPreview() {
                 endDate = "2026-02-07"
             ),
             viewMode = PlaceViewMode.LIST,
+            hasMorePages = false,
             onAction = {}
         )
     }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/TripDetailScreen.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/TripDetailScreen.kt
@@ -90,6 +90,7 @@ private fun TripDetailScreenContent(
     modifier: Modifier = Modifier
 ) {
     var mapLoaded by rememberSaveable { mutableStateOf(false) }
+    var isBottomSheetExpanded by remember { mutableStateOf(false) }
     val markerImages = rememberBitmapMarkerLoader(
         imageUrls = places.map { it.thumbnailImage.url }
     )
@@ -99,8 +100,7 @@ private fun TripDetailScreenContent(
             TripDetailTopBar(
                 title = tripName,
                 onBackClick = { onAction(TripDetailAction.OnBackClick) },
-                onMenuClick = { onAction(TripDetailAction.OnMenuClick) },
-                onSearchClick = { onAction(TripDetailAction.OnSearchClick) }
+                isBottomSheetExpanded = isBottomSheetExpanded
             )
         },
         contentWindowInsets = WindowInsets.navigationBars,
@@ -119,6 +119,9 @@ private fun TripDetailScreenContent(
             startDate = tripInfo?.startDate,
             endDate = tripInfo?.endDate,
             viewMode = viewMode,
+            onBottomSheetExpandedChange = { isExpanded ->
+                isBottomSheetExpanded = isExpanded
+            },
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues = innerPadding)

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/TripDetailViewModel.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/TripDetailViewModel.kt
@@ -155,6 +155,16 @@ class TripDetailViewModel @AssistedInject constructor(
                 }
             }
 
+            is TripDetailAction.OnNavigateToPlaceDetail -> {
+                _uiState.update {
+                    it.copy(
+                        mapSelectedPlace = null,
+                        mapBottomSheetContent = MapBottomSheetStep.PlaceList
+                    )
+                }
+                _event.trySend(element = TripDetailEvent.NavigateToPlaceDetail(id = action.placeId))
+            }
+
             is TripDetailAction.OnMapPlacesUpdate -> {
                 updatePlacesList(action.places)
             }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/component/BottomSheetPlaceDetailContent.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/component/BottomSheetPlaceDetailContent.kt
@@ -4,28 +4,34 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImagePainter.State.Empty.painter
 import com.andone.memorip.presentation.R
 import com.andone.memorip.presentation.component.MemoripImage
 import com.andone.memorip.presentation.component.PlaceLocationText
 import com.andone.memorip.presentation.component.TagChipRow
 import com.andone.memorip.presentation.model.Place
-import androidx.compose.ui.unit.dp
 import com.andone.memorip.presentation.theme.MemoripPadding
 import com.andone.memorip.presentation.theme.MemoripSpace
 import com.andone.memorip.presentation.theme.MemoripTheme
@@ -33,14 +39,17 @@ import com.andone.memorip.presentation.util.DummyData
 import kotlinx.collections.immutable.toImmutableList
 
 private object BottomSheetPlaceDetailContentDimen {
-    val IMAGE_SIZE = 80.dp
-    val IMAGE_CORNER_RADIUS = 12.dp
+    val IMAGE_SIZE = 100.dp
+    val IMAGE_CORNER_RADIUS = 8.dp
+    val BOTTOM_BUTTON_CORNER_RADIUS = 12.dp
+    val BUTTON_ICON_SIZE = 20.dp
 }
 
 @Composable
 fun BottomSheetPlaceDetailContent(
     place: Place,
     onCloseClick: () -> Unit,
+    onDetailClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Box(
@@ -50,25 +59,25 @@ fun BottomSheetPlaceDetailContent(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(
-                    horizontal = MemoripPadding.PaddingMedium,
-                    vertical = MemoripPadding.PaddingMedium
+                    horizontal = MemoripPadding.AppHorizontalPadding
                 ),
-            verticalArrangement = Arrangement.spacedBy(MemoripSpace.SpaceMedium)
+            verticalArrangement = Arrangement.spacedBy(MemoripSpace.SpaceXSmall)
         ) {
             Row(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
             ) {
                 Text(
                     text = place.name,
-                    modifier = modifier.weight(1f),
+                    modifier = Modifier.weight(1f),
                     color = MemoripTheme.colors.onSurface,
-                    style = MemoripTheme.typography.titleBold16
+                    style = MemoripTheme.typography.headlineBold20
                 )
 
                 IconButton(
                     onClick = onCloseClick,
-                    modifier = modifier
+                    modifier = Modifier
                 ) {
                     Icon(
                         painter = painterResource(R.drawable.ic_close),
@@ -95,7 +104,7 @@ fun BottomSheetPlaceDetailContent(
                     modifier = Modifier
                         .weight(1f)
                         .fillMaxWidth(),
-                    verticalArrangement = Arrangement.spacedBy(MemoripSpace.SpaceSmall)
+                    verticalArrangement = Arrangement.spacedBy(MemoripSpace.SpaceXSmall)
                 ) {
                     PlaceLocationText(
                         address = place.address,
@@ -107,6 +116,27 @@ fun BottomSheetPlaceDetailContent(
                         TagChipRow(
                             tags = place.categories.toImmutableList(),
                             modifier = Modifier.fillMaxWidth()
+                        )
+                    }
+                    TextButton(
+                        onClick = onDetailClick,
+                        modifier = Modifier.fillMaxWidth(),
+                        shape = RoundedCornerShape(BottomSheetPlaceDetailContentDimen.BOTTOM_BUTTON_CORNER_RADIUS),
+                        colors = ButtonDefaults.textButtonColors(
+                            containerColor = MemoripTheme.colors.primary,
+                            contentColor = MemoripTheme.colors.white
+                        )
+                    ) {
+                        Text(
+                            text = stringResource(R.string.place_detail_bottom_sheet_go_to_detail),
+                            style = MemoripTheme.typography.bodyMedium14
+                        )
+                        Spacer(modifier = Modifier.width(MemoripSpace.SpaceXSmall))
+                        Icon(
+                            painter = painterResource(R.drawable.ic_arrow_forward),
+                            contentDescription = null,
+                            modifier = Modifier.size(BottomSheetPlaceDetailContentDimen.BUTTON_ICON_SIZE),
+                            tint = MemoripTheme.colors.white
                         )
                     }
                 }
@@ -121,7 +151,8 @@ private fun BottomSheetPlaceDetailContentPreview() {
     MemoripTheme {
         BottomSheetPlaceDetailContent(
             place = DummyData.places.last(),
-            onCloseClick = {}
+            onCloseClick = {},
+            onDetailClick = {}
         )
     }
 }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/component/BottomSheetPlaceListHeader.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/component/BottomSheetPlaceListHeader.kt
@@ -59,7 +59,6 @@ fun BottomSheetPlaceListHeader(
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically
     ) {
-        // 다음 페이지 여부에 따라 다른 문자열 리소스 사용
         Text(
             text = if (hasMorePages) {
                 stringResource(R.string.trip_detail_place_list_count_format_more, placeCount)

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/component/BottomSheetPlaceListHeader.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/component/BottomSheetPlaceListHeader.kt
@@ -42,11 +42,12 @@ private object PlaceListHeaderDimen {
 }
 
 @Composable
-fun PlaceListHeader(
+fun BottomSheetPlaceListHeader(
     placeCount: Int,
     viewMode: PlaceViewMode,
     onViewModeToggle: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    hasMorePages: Boolean = false
 ) {
     Row(
         modifier = modifier
@@ -58,8 +59,13 @@ fun PlaceListHeader(
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically
     ) {
+        // 다음 페이지 여부에 따라 다른 문자열 리소스 사용
         Text(
-            text = stringResource(R.string.trip_detail_place_list_count_format, placeCount),
+            text = if (hasMorePages) {
+                stringResource(R.string.trip_detail_place_list_count_format_more, placeCount)
+            } else {
+                stringResource(R.string.trip_detail_place_list_count_format, placeCount)
+            },
             style = MemoripTheme.typography.headlineBold20,
             color = MemoripTheme.colors.onSurface
         )
@@ -153,7 +159,7 @@ private fun ViewModeToggleSegment(
 @Preview(showBackground = true)
 @Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
-private fun ViewModeTogglePreview() {
+private fun BottomSheetViewModeTogglePreview() {
     MemoripTheme {
         Row(
             modifier = Modifier
@@ -176,12 +182,12 @@ private fun ViewModeTogglePreview() {
 @Preview(showBackground = true)
 @Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
-private fun PlaceListHeaderPreview() {
+private fun BottomSheetPlaceListHeaderPreview() {
     MemoripTheme {
         androidx.compose.foundation.layout.Column(
             modifier = Modifier.background(MemoripTheme.colors.background)
         ) {
-            PlaceListHeader(
+            BottomSheetPlaceListHeader(
                 placeCount = 4,
                 viewMode = PlaceViewMode.LIST,
                 onViewModeToggle = {}

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/component/MapTab.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/component/MapTab.kt
@@ -87,6 +87,7 @@ fun MapTab(
     startDate: String? = null,
     endDate: String? = null,
     viewMode: PlaceViewMode = PlaceViewMode.LIST,
+    hasMorePages: Boolean = false,
     onBottomSheetExpandedChange: (Boolean) -> Unit = {}
 ) {
     val scaffoldState = rememberBottomSheetScaffoldState()
@@ -213,6 +214,7 @@ fun MapTab(
                     places = places,
                     selectedPlace = mapSelectedPlace,
                     viewMode = viewMode,
+                    hasMorePages = hasMorePages,
                     onAction = onAction,
                     isExpanded = isBottomSheetExpanded
                 )
@@ -282,6 +284,7 @@ private fun MapBottomSheetContent(
     viewMode: PlaceViewMode,
     onAction: (TripDetailAction) -> Unit,
     modifier: Modifier = Modifier,
+    hasMorePages: Boolean = false,
     isExpanded: Boolean = false
 ) {
     val placeListState = rememberLazyListState()
@@ -290,14 +293,14 @@ private fun MapBottomSheetContent(
         tonalElevation = MemoripShadow.Large,
         shadowElevation = MemoripShadow.Large,
         color = MemoripTheme.colors.background,
-        shape = if (isExpanded) {
-            RoundedCornerShape(0.dp)
-        } else {
-            RoundedCornerShape(
-                topStart = 16.dp,
-                topEnd = 16.dp
-            )
-        }
+//        shape = if (isExpanded) {
+//            RoundedCornerShape(0.dp)
+//        } else {
+//            RoundedCornerShape(
+//                topStart = 16.dp,
+//                topEnd = 16.dp
+//            )
+//        }
     ) {
         Column(
             modifier = Modifier
@@ -305,7 +308,6 @@ private fun MapBottomSheetContent(
                 .padding(top = if (isExpanded) 0.dp else MemoripPadding.PaddingSmall),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            // expanded 상태일 때 핸들 제거
             if (!isExpanded) {
                 Box(
                     modifier = Modifier
@@ -322,9 +324,10 @@ private fun MapBottomSheetContent(
                         Column(
                             modifier = Modifier.fillMaxSize()
                         ) {
-                            PlaceListHeader(
+                            BottomSheetPlaceListHeader(
                                 placeCount = places.size,
                                 viewMode = viewMode,
+                                hasMorePages = hasMorePages,
                                 onViewModeToggle = { onAction(TripDetailAction.OnViewModeToggle) }
                             )
 

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/component/MapTab.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/component/MapTab.kt
@@ -97,7 +97,7 @@ fun MapTab(
     val isBottomSheetExpanded by remember {
         derivedStateOf {
             try {
-                scaffoldState.bottomSheetState.requireOffset() <= 0.5f
+                scaffoldState.bottomSheetState.requireOffset() <= 20f
             } catch (e: IllegalStateException) {
                 false
             }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/component/MapTab.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/component/MapTab.kt
@@ -202,6 +202,7 @@ fun MapTab(
             sheetPeekHeight = MapTabDimen.SHEET_PEEK_HEIGHT,
             sheetContainerColor = MemoripTheme.colors.background,
             sheetDragHandle = null,
+            sheetSwipeEnabled = mapBottomSheetContent != MapBottomSheetStep.PlaceDetail,
             modifier = Modifier.fillMaxSize()
         ) {
             InteractiveMultiMarkerMapView(
@@ -283,42 +284,51 @@ private fun MapBottomSheetContent(
                     .background(MemoripTheme.colors.gray1)
             )
             Spacer(modifier = Modifier.height(MemoripPadding.PaddingXSmall))
-            when (bottomSheetContent) {
-                MapBottomSheetStep.PlaceList -> {
-                    Column(
-                        modifier = Modifier.fillMaxSize()
-                    ) {
-                        PlaceListHeader(
-                            placeCount = places.size,
-                            viewMode = viewMode,
-                            onViewModeToggle = { onAction(TripDetailAction.OnViewModeToggle) }
-                        )
+            Box(modifier = Modifier.weight(1f)) {
+                when (bottomSheetContent) {
+                    MapBottomSheetStep.PlaceList -> {
+                        Column(
+                            modifier = Modifier.fillMaxSize()
+                        ) {
+                            PlaceListHeader(
+                                placeCount = places.size,
+                                viewMode = viewMode,
+                                onViewModeToggle = { onAction(TripDetailAction.OnViewModeToggle) }
+                            )
 
-                        when (viewMode) {
-                            PlaceViewMode.LIST -> {
-                                BottomSheetPlaceListContent(
-                                    places = places,
-                                    listState = placeListState,
-                                    onAction = onAction
-                                )
-                            }
+                            when (viewMode) {
+                                PlaceViewMode.LIST -> {
+                                    BottomSheetPlaceListContent(
+                                        places = places,
+                                        listState = placeListState,
+                                        onAction = onAction
+                                    )
+                                }
 
-                            PlaceViewMode.GRID -> {
-                                BottomSheetPlaceGridContent(
-                                    places = places,
-                                    onAction = onAction
-                                )
+                                PlaceViewMode.GRID -> {
+                                    BottomSheetPlaceGridContent(
+                                        places = places,
+                                        onAction = onAction
+                                    )
+                                }
                             }
                         }
                     }
-                }
 
-                MapBottomSheetStep.PlaceDetail -> {
-                    selectedPlace?.let { place ->
-                        BottomSheetPlaceDetailContent(
-                            place = place,
-                            onCloseClick = { onAction(TripDetailAction.OnPlaceDetailBottomSheetClose) }
-                        )
+                    MapBottomSheetStep.PlaceDetail -> {
+                        selectedPlace?.let { place ->
+                            BottomSheetPlaceDetailContent(
+                                place = place,
+                                onCloseClick = { onAction(TripDetailAction.OnPlaceDetailBottomSheetClose) },
+                                onDetailClick = {
+                                    onAction(
+                                        TripDetailAction.OnNavigateToPlaceDetail(
+                                            place.placeId
+                                        )
+                                    )
+                                }
+                            )
+                        }
                     }
                 }
             }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/component/MapTab.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/component/MapTab.kt
@@ -292,15 +292,7 @@ private fun MapBottomSheetContent(
     Surface(
         tonalElevation = MemoripShadow.Large,
         shadowElevation = MemoripShadow.Large,
-        color = MemoripTheme.colors.background,
-//        shape = if (isExpanded) {
-//            RoundedCornerShape(0.dp)
-//        } else {
-//            RoundedCornerShape(
-//                topStart = 16.dp,
-//                topEnd = 16.dp
-//            )
-//        }
+        color = MemoripTheme.colors.background
     ) {
         Column(
             modifier = Modifier

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/component/MapTab.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/component/MapTab.kt
@@ -236,21 +236,20 @@ fun MapTab(
             }
         }
 
-        // todo: TripScheduleCard 추가
-//        if (startDate != null && endDate != null && tripName != null) {
-//            TripScheduleCard(
-//                tripName = tripName,
-//                startDate = startDate,
-//                endDate = endDate,
-//                modifier = Modifier
-//                    .align(Alignment.TopCenter)
-//                    .padding(
-//                        top = MemoripPadding.PaddingMedium,
-//                        start = MemoripPadding.PaddingMedium,
-//                        end = MemoripPadding.PaddingMedium
-//                    )
-//            )
-//        }
+        if (startDate != null && endDate != null && tripName != null) {
+            TripScheduleCard(
+                tripName = tripName,
+                startDate = startDate,
+                endDate = endDate,
+                modifier = Modifier
+                    .align(Alignment.TopCenter)
+                    .padding(
+                        top = MemoripPadding.PaddingMedium,
+                        start = MemoripPadding.PaddingMedium,
+                        end = MemoripPadding.PaddingMedium
+                    )
+            )
+        }
     }
 }
 

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/component/MapTab.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/component/MapTab.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.rememberBottomSheetScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -45,6 +46,8 @@ import androidx.compose.ui.unit.dp
 import com.andone.memorip.presentation.theme.MemoripTheme
 import androidx.compose.ui.Alignment
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.BottomSheetDefaults
+import androidx.compose.ui.graphics.RectangleShape
 import com.andone.memorip.presentation.util.DummyData
 import com.naver.maps.geometry.LatLng
 import com.naver.maps.geometry.LatLngBounds
@@ -83,12 +86,27 @@ fun MapTab(
     tripName: String? = null,
     startDate: String? = null,
     endDate: String? = null,
-    viewMode: PlaceViewMode = PlaceViewMode.LIST
+    viewMode: PlaceViewMode = PlaceViewMode.LIST,
+    onBottomSheetExpandedChange: (Boolean) -> Unit = {}
 ) {
     val scaffoldState = rememberBottomSheetScaffoldState()
     val scope = rememberCoroutineScope()
     val cameraPositionState: CameraPositionState = rememberCameraPositionState()
     var savedPlaceListSheetValue by remember { mutableStateOf<SheetValue?>(null) }
+
+    val isBottomSheetExpanded by remember {
+        derivedStateOf {
+            try {
+                scaffoldState.bottomSheetState.requireOffset() <= 0.5f
+            } catch (e: IllegalStateException) {
+                false
+            }
+        }
+    }
+
+    LaunchedEffect(isBottomSheetExpanded) {
+        onBottomSheetExpandedChange(isBottomSheetExpanded)
+    }
 
     LaunchedEffect(Unit) {
         scaffoldState.bottomSheetState.partialExpand()
@@ -189,17 +207,19 @@ fun MapTab(
         }
 
         BottomSheetScaffold(
-            scaffoldState = scaffoldState,
             sheetContent = {
                 MapBottomSheetContent(
                     bottomSheetContent = mapBottomSheetContent,
                     places = places,
                     selectedPlace = mapSelectedPlace,
                     viewMode = viewMode,
-                    onAction = onAction
+                    onAction = onAction,
+                    isExpanded = isBottomSheetExpanded
                 )
             },
+            scaffoldState = scaffoldState,
             sheetPeekHeight = MapTabDimen.SHEET_PEEK_HEIGHT,
+            sheetShape = if (isBottomSheetExpanded) RectangleShape else BottomSheetDefaults.ExpandedShape,
             sheetContainerColor = MemoripTheme.colors.background,
             sheetDragHandle = null,
             sheetSwipeEnabled = mapBottomSheetContent != MapBottomSheetStep.PlaceDetail,
@@ -261,29 +281,41 @@ private fun MapBottomSheetContent(
     selectedPlace: Place?,
     viewMode: PlaceViewMode,
     onAction: (TripDetailAction) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    isExpanded: Boolean = false
 ) {
     val placeListState = rememberLazyListState()
 
     Surface(
         tonalElevation = MemoripShadow.Large,
         shadowElevation = MemoripShadow.Large,
-        color = MemoripTheme.colors.background
+        color = MemoripTheme.colors.background,
+        shape = if (isExpanded) {
+            RoundedCornerShape(0.dp)
+        } else {
+            RoundedCornerShape(
+                topStart = 16.dp,
+                topEnd = 16.dp
+            )
+        }
     ) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(top = MemoripPadding.PaddingSmall),
+                .padding(top = if (isExpanded) 0.dp else MemoripPadding.PaddingSmall),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Box(
-                modifier = Modifier
-                    .width(MemoripPadding.PaddingXXXLarge)
-                    .height(MemoripSpace.SpaceXXSmall)
-                    .clip(RoundedCornerShape(MemoripLineWidth.Small))
-                    .background(MemoripTheme.colors.gray1)
-            )
-            Spacer(modifier = Modifier.height(MemoripPadding.PaddingXSmall))
+            // expanded 상태일 때 핸들 제거
+            if (!isExpanded) {
+                Box(
+                    modifier = Modifier
+                        .width(MemoripPadding.PaddingXXXLarge)
+                        .height(MemoripSpace.SpaceXXSmall)
+                        .clip(RoundedCornerShape(MemoripLineWidth.Small))
+                        .background(MemoripTheme.colors.gray1)
+                )
+                Spacer(modifier = Modifier.height(MemoripPadding.PaddingXSmall))
+            }
             Box(modifier = Modifier.weight(1f)) {
                 when (bottomSheetContent) {
                     MapBottomSheetStep.PlaceList -> {

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/component/PlaceImageMarkers.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/component/PlaceImageMarkers.kt
@@ -30,6 +30,9 @@ fun PlaceImageMarkers(
     // 클러스터 마커 렌더링
     clusteredItems.filter { it.isCluster }.forEach { clusterItem ->
         val clusterKey = "cluster_${clusterItem.position}_${clusterItem.count}"
+        val firstImageUrl = clusterItem.places.firstOrNull()?.imageUrl
+        val clusterImageBitmap = firstImageUrl?.let { markerImages[it] }
+        
         key(clusterKey) {
             MarkerComposable(
                 keys = arrayOf("cluster", clusterItem.position.toString(), clusterItem.count.toString()),
@@ -39,7 +42,10 @@ fun PlaceImageMarkers(
                     true
                 }
             ) {
-                ClusterMarker(count = clusterItem.count)
+                ClusterMarker(
+                    count = clusterItem.count,
+                    imageBitmap = clusterImageBitmap
+                )
             }
         }
     }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/component/TripDetailTopBar.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/component/TripDetailTopBar.kt
@@ -4,6 +4,7 @@ import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
@@ -11,42 +12,55 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.andone.memorip.presentation.R
+import com.andone.memorip.presentation.screen.tripdetail.component.TripDetailTopBarDimen.ELEVATION_EXPANDED
+import com.andone.memorip.presentation.screen.tripdetail.component.TripDetailTopBarDimen.ELEVATION_NORMAL
 import com.andone.memorip.presentation.theme.MemoripTheme
+
+private object TripDetailTopBarDimen {
+    val ELEVATION_NORMAL = 0.dp
+    val ELEVATION_EXPANDED = 8.dp
+}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TripDetailTopBar(
     title: String,
     onBackClick: () -> Unit,
-    onMenuClick: () -> Unit,
-    onSearchClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    isBottomSheetExpanded: Boolean = false
 ) {
-    CenterAlignedTopAppBar(
-        title = {
-            Text(
-                text = title,
-                style = MemoripTheme.typography.headlineBold20,
-                color = MemoripTheme.colors.onSurface
-            )
-        },
-        navigationIcon = {
-            IconButton(onClick = onBackClick) {
-                Icon(
-                    painter = painterResource(R.drawable.ic_arrow_back),
-                    contentDescription = stringResource(R.string.trip_detail_back_button_content_description)
-                )
-            }
-        },
-        colors = TopAppBarDefaults.topAppBarColors(
-            containerColor = MemoripTheme.colors.background,
-            navigationIconContentColor = MemoripTheme.colors.onSurface,
-            titleContentColor = MemoripTheme.colors.onSurface,
-            actionIconContentColor = MemoripTheme.colors.onSurface
-        ),
+    Surface(
+        shadowElevation = if (isBottomSheetExpanded) ELEVATION_EXPANDED else ELEVATION_NORMAL,
+        tonalElevation = 0.dp,
+        color = MemoripTheme.colors.background,
         modifier = modifier
-    )
+    ) {
+        CenterAlignedTopAppBar(
+            title = {
+                Text(
+                    text = title,
+                    style = MemoripTheme.typography.headlineBold20,
+                    color = MemoripTheme.colors.onSurface
+                )
+            },
+            navigationIcon = {
+                IconButton(onClick = onBackClick) {
+                    Icon(
+                        painter = painterResource(R.drawable.ic_arrow_back),
+                        contentDescription = stringResource(R.string.trip_detail_back_button_content_description)
+                    )
+                }
+            },
+            colors = TopAppBarDefaults.topAppBarColors(
+                containerColor = MemoripTheme.colors.background,
+                navigationIconContentColor = MemoripTheme.colors.onSurface,
+                titleContentColor = MemoripTheme.colors.onSurface,
+                actionIconContentColor = MemoripTheme.colors.onSurface
+            )
+        )
+    }
 }
 
 @Preview
@@ -55,9 +69,7 @@ private fun TripDetailTopBarPreview() {
     MemoripTheme {
         TripDetailTopBar(
             title = "Trip1",
-            onBackClick = {},
-            onSearchClick = {},
-            onMenuClick = {}
+            onBackClick = {}
         )
     }
 }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/component/TripDetailTopBar.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/component/TripDetailTopBar.kt
@@ -39,14 +39,6 @@ fun TripDetailTopBar(
                 )
             }
         },
-        actions = {
-            IconButton(onClick = onSearchClick) {
-                Icon(
-                    painter = painterResource(R.drawable.ic_search),
-                    contentDescription = stringResource(R.string.trip_detail_search_button_content_description)
-                )
-            }
-        },
         colors = TopAppBarDefaults.topAppBarColors(
             containerColor = MemoripTheme.colors.background,
             navigationIconContentColor = MemoripTheme.colors.onSurface,

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/component/TripMap.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/component/TripMap.kt
@@ -1,0 +1,247 @@
+package com.andone.memorip.presentation.screen.tripdetail.component
+
+import android.graphics.Bitmap
+import androidx.activity.compose.BackHandler
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.SheetValue
+import androidx.compose.material3.rememberBottomSheetScaffoldState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Modifier
+import com.andone.memorip.presentation.component.map.MapClusterManager
+import com.andone.memorip.presentation.model.Place
+import com.andone.memorip.presentation.screen.tripdetail.model.MapBottomSheetStep
+import com.andone.memorip.presentation.screen.tripdetail.model.PlaceViewMode
+import com.andone.memorip.presentation.screen.tripdetail.model.TripDetailAction
+import com.naver.maps.geometry.LatLng
+import com.naver.maps.geometry.LatLngBounds
+import com.naver.maps.map.CameraUpdate
+import com.naver.maps.map.compose.CameraPositionState
+import com.naver.maps.map.compose.ExperimentalNaverMapApi
+import com.naver.maps.map.compose.rememberCameraPositionState
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.launch
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.foundation.layout.fillMaxSize
+import com.andone.memorip.presentation.theme.MemoripTheme
+import com.andone.memorip.presentation.util.DummyData
+
+private object TripMapConstant {
+    const val BOUND_PADDING = 200
+    const val CAMERA_ANIMATION_DURATION = 500
+    const val MICRO_ANIMATION_DURATION = 1
+    const val MICRO_ZOOM_DELTA = 0.0001
+    const val CAMERA_UPDATE_DELAY = 100L
+}
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalNaverMapApi::class)
+@Composable
+fun TripMap(
+    places: List<Place>,
+    clusteredItems: List<MapClusterManager.ClusterItem>,
+    markerImages: Map<String, Bitmap>,
+    mapBottomSheetContent: MapBottomSheetStep,
+    mapLoaded: Boolean,
+    onMapLoaded: () -> Unit,
+    onAction: (TripDetailAction) -> Unit,
+    modifier: Modifier = Modifier,
+    mapSelectedPlace: Place? = null,
+    tripName: String? = null,
+    startDate: String? = null,
+    endDate: String? = null,
+    viewMode: PlaceViewMode = PlaceViewMode.LIST,
+    hasMorePages: Boolean = false,
+    onBottomSheetExpandedChange: (Boolean) -> Unit = {}
+) {
+    val scaffoldState = rememberBottomSheetScaffoldState()
+    val scope = rememberCoroutineScope()
+    val cameraPositionState: CameraPositionState = rememberCameraPositionState()
+    var savedPlaceListSheetValue by remember { mutableStateOf<SheetValue?>(null) }
+
+    val isBottomSheetExpanded by remember {
+        derivedStateOf {
+            try {
+                scaffoldState.bottomSheetState.requireOffset() <= 20f
+            } catch (e: IllegalStateException) {
+                false
+            }
+        }
+    }
+
+    LaunchedEffect(isBottomSheetExpanded) {
+        onBottomSheetExpandedChange(isBottomSheetExpanded)
+    }
+
+    LaunchedEffect(Unit) {
+        scaffoldState.bottomSheetState.partialExpand()
+    }
+
+    LaunchedEffect(places, cameraPositionState, mapSelectedPlace) {
+        var isCameraInitialized = false
+        var lastSelectedPlaceId: String? = null
+
+        combine(
+            snapshotFlow { places },
+            snapshotFlow {
+                val isMoving = cameraPositionState.isMoving
+                val projection = cameraPositionState.projection
+                val zoom = cameraPositionState.position.zoom
+
+                if (isMoving) {
+                    null
+                } else if (projection != null) {
+                    Pair(projection, zoom)
+                } else {
+                    null
+                }
+            }.distinctUntilChanged(),
+            snapshotFlow { mapSelectedPlace }
+        ) { currentPlaces, cameraData, selectedPlace ->
+            Triple(currentPlaces, cameraData, selectedPlace)
+        }
+            .collect { (currentPlaces, cameraData, selectedPlace) ->
+                // 지도 초기화: 모든 장소를 포함하도록 카메라 설정
+                if (currentPlaces.isNotEmpty() && !isCameraInitialized) {
+                    val bounds = LatLngBounds.Builder().apply {
+                        currentPlaces.forEach { place ->
+                            include(LatLng(place.latitude, place.longitude))
+                        }
+                    }.build()
+
+                    val cameraUpdate = CameraUpdate.fitBounds(bounds, TripMapConstant.BOUND_PADDING)
+                    cameraPositionState.move(cameraUpdate)
+                    scope.launch {
+                        delay(TripMapConstant.CAMERA_UPDATE_DELAY)
+                        val microUpdate = CameraUpdate.zoomBy(TripMapConstant.MICRO_ZOOM_DELTA)
+                        cameraPositionState.animate(
+                            update = microUpdate,
+                            durationMs = TripMapConstant.MICRO_ANIMATION_DURATION
+                        )
+                    }
+                    onAction(TripDetailAction.OnMapPlacesUpdate(currentPlaces))
+
+                    isCameraInitialized = true
+                    onAction(TripDetailAction.OnMapInitialized)
+                }
+
+                if (isCameraInitialized && cameraData != null) {
+                    val (projection, zoom) = cameraData
+                    onAction(TripDetailAction.OnMapCameraChange(projection, zoom))
+                }
+
+                if (selectedPlace != null && selectedPlace.placeId != lastSelectedPlaceId) {
+                    lastSelectedPlaceId = selectedPlace.placeId
+                    scope.launch {
+                        val cameraUpdate = CameraUpdate.scrollTo(
+                            LatLng(selectedPlace.latitude, selectedPlace.longitude)
+                        )
+                        cameraPositionState.animate(
+                            update = cameraUpdate,
+                            durationMs = TripMapConstant.CAMERA_ANIMATION_DURATION
+                        )
+                    }
+                } else if (selectedPlace == null) {
+                    lastSelectedPlaceId = null
+                }
+            }
+    }
+
+    LaunchedEffect(mapBottomSheetContent) {
+        when (mapBottomSheetContent) {
+            MapBottomSheetStep.PlaceList -> {
+                when (savedPlaceListSheetValue) {
+                    SheetValue.Expanded -> scaffoldState.bottomSheetState.expand()
+                    else -> scaffoldState.bottomSheetState.partialExpand()
+                }
+            }
+
+            MapBottomSheetStep.PlaceDetail -> {
+                savedPlaceListSheetValue = scaffoldState.bottomSheetState.currentValue
+                scaffoldState.bottomSheetState.partialExpand()
+            }
+        }
+    }
+
+    BackHandler(enabled = mapBottomSheetContent == MapBottomSheetStep.PlaceDetail) {
+        onAction(TripDetailAction.OnPlaceDetailBottomSheetClose)
+    }
+
+    TripMapContent(
+        places = places,
+        clusteredItems = clusteredItems,
+        markerImages = markerImages,
+        cameraPositionState = cameraPositionState,
+        scaffoldState = scaffoldState,
+        isBottomSheetExpanded = isBottomSheetExpanded,
+        mapLoaded = mapLoaded,
+        mapBottomSheetContent = mapBottomSheetContent,
+        mapSelectedPlace = mapSelectedPlace,
+        tripName = tripName,
+        startDate = startDate,
+        endDate = endDate,
+        viewMode = viewMode,
+        hasMorePages = hasMorePages,
+        onAction = onAction,
+        onMarkerClick = { place ->
+            onAction(TripDetailAction.OnPlaceClick(place = place))
+        },
+        onClusterClick = { clusterItem ->
+            scope.launch {
+                val cameraUpdate = CameraUpdate
+                    .scrollAndZoomTo(
+                        clusterItem.position,
+                        cameraPositionState.position.zoom + 1
+                    )
+                cameraPositionState.animate(
+                    update = cameraUpdate,
+                    durationMs = TripMapConstant.CAMERA_ANIMATION_DURATION
+                )
+            }
+        },
+        onMapLoaded = onMapLoaded,
+        modifier = modifier
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalNaverMapApi::class)
+@Preview(showBackground = true)
+@Composable
+private fun TripMapPreview() {
+    MemoripTheme {
+        val clusteredItems = DummyData.places.map { place ->
+            MapClusterManager.ClusterItem(
+                position = LatLng(place.latitude, place.longitude),
+                places = listOf(
+                    MapClusterManager.PlaceClusterData(
+                        id = place.placeId,
+                        position = LatLng(place.latitude, place.longitude),
+                        imageUrl = place.thumbnailImage.url,
+                        placeData = place
+                    )
+                ),
+                isCluster = false
+            )
+        }
+
+        TripMap(
+            places = DummyData.places,
+            clusteredItems = clusteredItems,
+            markerImages = emptyMap(),
+            mapBottomSheetContent = MapBottomSheetStep.PlaceList,
+            mapLoaded = true,
+            onMapLoaded = {},
+            onAction = {},
+            viewMode = PlaceViewMode.LIST,
+            modifier = Modifier.fillMaxSize()
+        )
+    }
+}

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/component/TripMapContent.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/component/TripMapContent.kt
@@ -1,207 +1,75 @@
 package com.andone.memorip.presentation.screen.tripdetail.component
 
 import android.graphics.Bitmap
-import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.BottomSheetScaffold
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.SheetValue
-import androidx.compose.material3.Surface
-import androidx.compose.material3.rememberBottomSheetScaffoldState
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.derivedStateOf
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshotFlow
-import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.distinctUntilChanged
+import androidx.compose.material3.BottomSheetScaffold
+import androidx.compose.material3.BottomSheetScaffoldState
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.unit.dp
 import com.andone.memorip.presentation.component.LoadingIndicatorScreen
 import com.andone.memorip.presentation.component.map.InteractiveMultiMarkerMapView
 import com.andone.memorip.presentation.component.map.MapClusterManager
 import com.andone.memorip.presentation.model.Place
+import com.andone.memorip.presentation.screen.tripdetail.model.MapBottomSheetStep
 import com.andone.memorip.presentation.screen.tripdetail.model.PlaceViewMode
 import com.andone.memorip.presentation.screen.tripdetail.model.TripDetailAction
-import com.andone.memorip.presentation.screen.tripdetail.model.MapBottomSheetStep
 import com.andone.memorip.presentation.theme.MemoripLineWidth
 import com.andone.memorip.presentation.theme.MemoripPadding
 import com.andone.memorip.presentation.theme.MemoripShadow
 import com.andone.memorip.presentation.theme.MemoripSpace
-import androidx.compose.ui.unit.dp
 import com.andone.memorip.presentation.theme.MemoripTheme
-import androidx.compose.ui.Alignment
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.BottomSheetDefaults
-import androidx.compose.ui.graphics.RectangleShape
-import com.andone.memorip.presentation.util.DummyData
 import com.naver.maps.geometry.LatLng
-import com.naver.maps.geometry.LatLngBounds
-import com.naver.maps.map.CameraUpdate
 import com.naver.maps.map.compose.CameraPositionState
 import com.naver.maps.map.compose.ExperimentalNaverMapApi
+import androidx.compose.material3.BottomSheetDefaults
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.ui.tooling.preview.Preview
+import com.andone.memorip.presentation.util.DummyData
 import com.naver.maps.map.compose.rememberCameraPositionState
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
+import androidx.compose.material3.rememberBottomSheetScaffoldState
 
-
-private object MapTabDimen {
+private object TripMapContentDimen {
     val SHEET_PEEK_HEIGHT = 200.dp
-}
-
-private object MapTabConstant {
-    const val BOUND_PADDING = 200
-    const val CAMERA_ANIMATION_DURATION = 500
-    const val MICRO_ANIMATION_DURATION = 1
-    const val MICRO_ZOOM_DELTA = 0.0001
-    const val CAMERA_UPDATE_DELAY = 100L
 }
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalNaverMapApi::class)
 @Composable
-fun MapTab(
+fun TripMapContent(
     places: List<Place>,
     clusteredItems: List<MapClusterManager.ClusterItem>,
     markerImages: Map<String, Bitmap>,
-    mapBottomSheetContent: MapBottomSheetStep,
+    cameraPositionState: CameraPositionState,
+    scaffoldState: BottomSheetScaffoldState,
+    isBottomSheetExpanded: Boolean,
     mapLoaded: Boolean,
-    onMapLoaded: () -> Unit,
+    mapBottomSheetContent: MapBottomSheetStep,
+    mapSelectedPlace: Place?,
+    tripName: String?,
+    startDate: String?,
+    endDate: String?,
+    viewMode: PlaceViewMode,
+    hasMorePages: Boolean,
     onAction: (TripDetailAction) -> Unit,
-    modifier: Modifier = Modifier,
-    mapSelectedPlace: Place? = null,
-    tripName: String? = null,
-    startDate: String? = null,
-    endDate: String? = null,
-    viewMode: PlaceViewMode = PlaceViewMode.LIST,
-    hasMorePages: Boolean = false,
-    onBottomSheetExpandedChange: (Boolean) -> Unit = {}
+    onMarkerClick: (Place) -> Unit,
+    onClusterClick: (MapClusterManager.ClusterItem) -> Unit,
+    onMapLoaded: () -> Unit,
+    modifier: Modifier = Modifier
 ) {
-    val scaffoldState = rememberBottomSheetScaffoldState()
-    val scope = rememberCoroutineScope()
-    val cameraPositionState: CameraPositionState = rememberCameraPositionState()
-    var savedPlaceListSheetValue by remember { mutableStateOf<SheetValue?>(null) }
-
-    val isBottomSheetExpanded by remember {
-        derivedStateOf {
-            try {
-                scaffoldState.bottomSheetState.requireOffset() <= 20f
-            } catch (e: IllegalStateException) {
-                false
-            }
-        }
-    }
-
-    LaunchedEffect(isBottomSheetExpanded) {
-        onBottomSheetExpandedChange(isBottomSheetExpanded)
-    }
-
-    LaunchedEffect(Unit) {
-        scaffoldState.bottomSheetState.partialExpand()
-    }
-
-    LaunchedEffect(places, cameraPositionState, mapSelectedPlace) {
-        var isCameraInitialized = false
-        var lastSelectedPlaceId: String? = null
-
-        combine(
-            snapshotFlow { places },
-            snapshotFlow {
-                val isMoving = cameraPositionState.isMoving
-                val projection = cameraPositionState.projection
-                val zoom = cameraPositionState.position.zoom
-
-                if (isMoving) {
-                    null
-                } else if (projection != null) {
-                    Pair(projection, zoom)
-                } else {
-                    null
-                }
-            }.distinctUntilChanged(),
-            snapshotFlow { mapSelectedPlace }
-        ) { currentPlaces, cameraData, selectedPlace ->
-            Triple(currentPlaces, cameraData, selectedPlace)
-        }
-            .collect { (currentPlaces, cameraData, selectedPlace) ->
-                if (currentPlaces.isNotEmpty() && !isCameraInitialized) {
-                    val bounds = LatLngBounds.Builder().apply {
-                        currentPlaces.forEach { place ->
-                            include(LatLng(place.latitude, place.longitude))
-                        }
-                    }.build()
-
-                    val cameraUpdate = CameraUpdate.fitBounds(bounds, MapTabConstant.BOUND_PADDING)
-                    cameraPositionState.move(cameraUpdate)
-                    scope.launch {
-                        delay(MapTabConstant.CAMERA_UPDATE_DELAY)
-                        val microUpdate = CameraUpdate.zoomBy(MapTabConstant.MICRO_ZOOM_DELTA)
-                        cameraPositionState.animate(
-                            update = microUpdate,
-                            durationMs = MapTabConstant.MICRO_ANIMATION_DURATION
-                        )
-                    }
-                    onAction(TripDetailAction.OnMapPlacesUpdate(currentPlaces))
-
-                    isCameraInitialized = true
-                    onAction(TripDetailAction.OnMapInitialized)
-                }
-
-                if (isCameraInitialized && cameraData != null) {
-                    val (projection, zoom) = cameraData
-                    onAction(TripDetailAction.OnMapCameraChange(projection, zoom))
-                }
-
-                if (selectedPlace != null && selectedPlace.placeId != lastSelectedPlaceId) {
-                    lastSelectedPlaceId = selectedPlace.placeId
-                    scope.launch {
-                        val cameraUpdate = CameraUpdate.scrollTo(
-                            LatLng(selectedPlace.latitude, selectedPlace.longitude)
-                        )
-                        cameraPositionState.animate(
-                            update = cameraUpdate,
-                            durationMs = MapTabConstant.CAMERA_ANIMATION_DURATION
-                        )
-                    }
-                } else if (selectedPlace == null) {
-                    lastSelectedPlaceId = null
-                }
-            }
-    }
-
-    LaunchedEffect(mapBottomSheetContent) {
-        when (mapBottomSheetContent) {
-            MapBottomSheetStep.PlaceList -> {
-                when (savedPlaceListSheetValue) {
-                    SheetValue.Expanded -> scaffoldState.bottomSheetState.expand()
-                    else -> scaffoldState.bottomSheetState.partialExpand()
-                }
-            }
-
-            MapBottomSheetStep.PlaceDetail -> {
-                savedPlaceListSheetValue = scaffoldState.bottomSheetState.currentValue
-                scaffoldState.bottomSheetState.partialExpand()
-            }
-        }
-    }
-
-    BackHandler(enabled = mapBottomSheetContent == MapBottomSheetStep.PlaceDetail) {
-        onAction(TripDetailAction.OnPlaceDetailBottomSheetClose)
-    }
-
     Box(modifier = modifier) {
         if (!mapLoaded) {
             LoadingIndicatorScreen(modifier = Modifier.fillMaxSize())
@@ -220,7 +88,7 @@ fun MapTab(
                 )
             },
             scaffoldState = scaffoldState,
-            sheetPeekHeight = MapTabDimen.SHEET_PEEK_HEIGHT,
+            sheetPeekHeight = TripMapContentDimen.SHEET_PEEK_HEIGHT,
             sheetShape = if (isBottomSheetExpanded) RectangleShape else BottomSheetDefaults.ExpandedShape,
             sheetContainerColor = MemoripTheme.colors.background,
             sheetDragHandle = null,
@@ -230,7 +98,7 @@ fun MapTab(
             InteractiveMultiMarkerMapView(
                 initialBounds = places.map { LatLng(it.latitude, it.longitude) },
                 onMapLoaded = onMapLoaded,
-                contentPadding = PaddingValues(bottom = MapTabDimen.SHEET_PEEK_HEIGHT),
+                contentPadding = PaddingValues(bottom = TripMapContentDimen.SHEET_PEEK_HEIGHT),
                 cameraPositionState = cameraPositionState,
                 modifier = Modifier.fillMaxSize()
             ) {
@@ -238,22 +106,8 @@ fun MapTab(
                     PlaceImageMarkers(
                         clusteredItems = clusteredItems,
                         markerImages = markerImages,
-                        onMarkerClick = { place ->
-                            onAction(TripDetailAction.OnPlaceClick(place = place))
-                        },
-                        onClusterClick = { clusterItem ->
-                            scope.launch {
-                                val cameraUpdate = CameraUpdate
-                                    .scrollAndZoomTo(
-                                        clusterItem.position,
-                                        cameraPositionState.position.zoom + 1
-                                    )
-                                cameraPositionState.animate(
-                                    update = cameraUpdate,
-                                    durationMs = MapTabConstant.CAMERA_ANIMATION_DURATION
-                                )
-                            }
-                        }
+                        onMarkerClick = onMarkerClick,
+                        onClusterClick = onClusterClick
                     )
                 }
             }
@@ -292,7 +146,7 @@ private fun MapBottomSheetContent(
     Surface(
         tonalElevation = MemoripShadow.Large,
         shadowElevation = MemoripShadow.Large,
-        color = MemoripTheme.colors.background
+        color = MemoripTheme.colors.background,
     ) {
         Column(
             modifier = Modifier
@@ -363,9 +217,10 @@ private fun MapBottomSheetContent(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalNaverMapApi::class)
 @Preview(showBackground = true)
 @Composable
-private fun MapTabPreview() {
+private fun TripMapContentPreview() {
     MemoripTheme {
         val clusteredItems = DummyData.places.map { place ->
             MapClusterManager.ClusterItem(
@@ -382,14 +237,24 @@ private fun MapTabPreview() {
             )
         }
 
-        MapTab(
+        TripMapContent(
             places = DummyData.places,
             clusteredItems = clusteredItems,
             markerImages = emptyMap(),
-            mapSelectedPlace = null,
-            mapBottomSheetContent = MapBottomSheetStep.PlaceList,
-            onAction = {},
+            cameraPositionState = rememberCameraPositionState(),
+            scaffoldState = rememberBottomSheetScaffoldState(),
+            isBottomSheetExpanded = false,
             mapLoaded = true,
+            mapBottomSheetContent = MapBottomSheetStep.PlaceList,
+            mapSelectedPlace = null,
+            tripName = "서울 여행",
+            startDate = "2026-02-05",
+            endDate = "2026-02-07",
+            viewMode = PlaceViewMode.LIST,
+            hasMorePages = false,
+            onAction = {},
+            onMarkerClick = {},
+            onClusterClick = {},
             onMapLoaded = {},
             modifier = Modifier.fillMaxSize()
         )

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/component/TripScheduleCard.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/component/TripScheduleCard.kt
@@ -1,0 +1,152 @@
+package com.andone.memorip.presentation.screen.tripdetail.component
+
+import android.content.res.Configuration
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.andone.memorip.presentation.R
+import com.andone.memorip.presentation.theme.MemoripElevation
+import com.andone.memorip.presentation.theme.MemoripIconSize
+import com.andone.memorip.presentation.theme.MemoripPadding
+import com.andone.memorip.presentation.theme.MemoripSpace
+import com.andone.memorip.presentation.theme.MemoripTheme
+import com.andone.memorip.presentation.util.calculateDDay
+import com.andone.memorip.presentation.util.formatDateRange
+
+private object TripScheduleCardDimen {
+    val PRIMARY_STRIP_WIDTH = 5.dp
+    val ICON_BOX_SIZE = 48.dp
+    val ICON_BOX_CORNER_RADIUS = 12.dp
+}
+
+@Composable
+fun TripScheduleCard(
+    tripName: String,
+    startDate: String,
+    endDate: String,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        shape = MemoripTheme.shapes.roundedSmall,
+        colors = CardDefaults.cardColors(containerColor = MemoripTheme.colors.background.copy(alpha = 0.95f)),
+        elevation = CardDefaults.cardElevation(defaultElevation = MemoripElevation.ElevationMedium)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(IntrinsicSize.Min),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(
+                modifier = Modifier
+                    .width(TripScheduleCardDimen.PRIMARY_STRIP_WIDTH)
+                    .fillMaxHeight()
+                    .clip(
+                        shape = RoundedCornerShape(
+                            topStart = MemoripPadding.PaddingSmall,
+                            bottomStart = MemoripPadding.PaddingSmall
+                        )
+                    )
+                    .background(MemoripTheme.colors.primary)
+            )
+            Box(
+                modifier = Modifier
+                    .padding(MemoripPadding.PaddingMedium)
+                    .size(TripScheduleCardDimen.ICON_BOX_SIZE)
+                    .clip(RoundedCornerShape(TripScheduleCardDimen.ICON_BOX_CORNER_RADIUS))
+                    .background(MemoripTheme.colors.primary.copy(alpha = 0.1f)),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_outline_calendar_month),
+                    contentDescription = null,
+                    tint = MemoripTheme.colors.primary,
+                    modifier = Modifier.size(MemoripIconSize.IconSizeMedium)
+                )
+            }
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(MemoripPadding.PaddingMedium),
+                verticalArrangement = Arrangement.spacedBy(MemoripSpace.SpaceXSmall)
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = stringResource(R.string.trip_detail_schedule_upcoming),
+                        style = MemoripTheme.typography.titleBold16,
+                        color = MemoripTheme.colors.primary
+                    )
+                    calculateDDay(startDate).takeIf { it.isNotEmpty() }?.let { dDay ->
+                        Text(
+                            text = dDay,
+                            style = MemoripTheme.typography.titleBold16,
+                            color = MemoripTheme.colors.primary
+                        )
+                    }
+                }
+                Text(
+                    text = stringResource(R.string.trip_detail_schedule_trip_format, tripName),
+                    style = MemoripTheme.typography.titleBold18,
+                    color = MemoripTheme.colors.onSurface,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                formatDateRange(startDate, endDate).takeIf { it.isNotEmpty() }?.let { dateRange ->
+                    Text(
+                        text = dateRange,
+                        style = MemoripTheme.typography.bodyBold16,
+                        color = MemoripTheme.colors.gray
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun TripScheduleCardPreview() {
+    MemoripTheme {
+        Column(
+            modifier = Modifier
+                .background(MemoripTheme.colors.primaryContainer)
+                .padding(MemoripPadding.PaddingMedium),
+            verticalArrangement = Arrangement.spacedBy(MemoripSpace.SpaceMedium)
+        ) {
+            TripScheduleCard(
+                tripName = "서울대공원 주암 나들이",
+                startDate = "2026-02-05",
+                endDate = "2026-02-07"
+            )
+        }
+    }
+}

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/model/TripDetailAction.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/model/TripDetailAction.kt
@@ -15,6 +15,8 @@ sealed interface TripDetailAction {
 
     data object OnPlaceDetailBottomSheetClose : TripDetailAction
 
+    data class OnNavigateToPlaceDetail(val placeId: String) : TripDetailAction
+
     data object OnViewModeToggle : TripDetailAction
 
     // Map 관련 액션

--- a/client/presentation/src/main/res/values/strings.xml
+++ b/client/presentation/src/main/res/values/strings.xml
@@ -132,6 +132,7 @@
     <string name="place_detail_view_in_map_app">지도 앱에서 보기</string>
     <string name="place_detail_chooser_title">지도 앱에서 위치 보기</string>
     <string name="place_detail_comma_separator">, </string>
+    <string name="place_detail_bottom_sheet_go_to_detail">상세 화면으로 이동하기</string>
 
     <!-- PlaceEdit -->
     <string name="place_edit_title">장소 수정</string>

--- a/client/presentation/src/main/res/values/strings.xml
+++ b/client/presentation/src/main/res/values/strings.xml
@@ -79,6 +79,7 @@
     <string name="trip_detail_search_button_content_description">검색</string>
     <string name="trip_detail_place_list_title">장소 목록</string>
     <string name="trip_detail_place_list_count_format">장소 목록 %1$d</string>
+    <string name="trip_detail_place_list_count_format_more">장소 목록 %1$d+</string>
     <string name="trip_detail_schedule_upcoming">다가오는 일정</string>
     <string name="trip_detail_schedule_trip_format">%1$s 여행</string>
     <string name="trip_detail_view_list_description">리스트 뷰</string>

--- a/client/presentation/src/main/res/values/strings.xml
+++ b/client/presentation/src/main/res/values/strings.xml
@@ -257,4 +257,7 @@
     <!-- PlacePickerItem -->
     <string name="place_picker_item_image_description">장소에 대한 이미지</string>
 
+    <!-- Map Cluster Marker -->
+    <string name="map_cluster_marker_max_count">99+</string>
+
 </resources>


### PR DESCRIPTION
## 📝 변경 사항
여행 상세 화면의 추가 UI/UX 개선 작업으로, 지도 마커 시각화 개선, 바텀시트 확장 시 UI 변경, 장소 상세 화면으로의 네비게이션 기능 등을 구현했습니다.

## 🎯 작업 내용
**지도 마커 UI 개선**
- 클러스터 마커에 대표 이미지 표시 기능 추가
- `ClusterMarker`에 `imageBitmap` 파라미터 추가하여 클러스터 내 첫 번째 장소 이미지 표시
- `ClusterMarker` 내부 텍스트 위치를 중앙에서 좌측 하단으로 변경
- 클러스터 및 이미지 마커의 테두리 두께를 `Medium`에서 `Small`로 변경
- `ImageMarker`의 기본 테두리 색상을 `primaryContainer`에서 `primary`로 변경

**바텀시트 확장 시 UI 개선**
- 바텀시트 확장 상태 감지 기능 추가 (`derivedStateOf` 사용)
- 바텀시트 확장 시 TopBar 그림자 조절
- 바텀시트 확장 시 상단 모서리 둥근 효과 및 드래그 핸들 제거하여 전체 화면처럼 표시
- 바텀시트 확장 판정 임계값 조정 (0.5f → 20f)

**장소 상세 화면 네비게이션 기능**
- `TripDetailNavGraph`에 `onNavigateToPlaceDetail` 콜백 파라미터 추가
- `MemoripNav`에서 장소 상세 화면으로 이동하는 내비게이션 로직 연결
- `TripDetailAction`에 `OnNavigateToPlaceDetail` 액션 추가
- `MapTab`에서 장소 상세 모드(`PlaceDetail`)일 때 바텀시트 스와이프 비활성화
- 장소 상세 화면으로 이동하는 버튼 추가

**TripScheduleCard 복원 및 적용**
- `TripScheduleCard.kt` 파일 생성 및 컴포넌트 구현
- `MapTab`에서 주석 처리되었던 `TripScheduleCard` 호출부 활성화
- 여행 일정 정보(이름, 날짜, D-Day) 표시

**UI 개선 사항**
- `TripDetailTopBar`에서 검색 버튼 삭제
- `BottomSheetPlaceListHeader`에 페이징 상태 표시 기능 추가
- 다음 페이지 존재 시 장소 개수 뒤에 '+' 기호 표시

## 영상

https://github.com/user-attachments/assets/b794349e-11e5-4fcb-9ceb-debf7629ebe0


## 🔗 관련 이슈
Closes #187

## 💬 리뷰어에게
- 바텀시트 확장 시 UI 전환이 자연스러운지 확인해주시면 감사하겠습니다.
- 현재 마커 border를 클러스터마커는 white, 장소 1개 마커는 primary로 설정해두었습니다. 클러스터 마커와 구분하기 위해 색깔 구분을 주었는데 이 부분도 괜찮은지 확인해주시면 감사하겠습니다.