### PR TITLE
[Refactor] 이미지 비트맵 생성 시 ImageLoader 싱글톤 사용으로 변경

### DIFF
--- a/client/app/build.gradle.kts
+++ b/client/app/build.gradle.kts
@@ -86,4 +86,8 @@ dependencies {
 
     // Java 8+ API desugaring (java.time 라이브러리 지원)
     coreLibraryDesugaring(libs.desugar.jdk.libs)
+
+    // Coil3
+    implementation(libs.coil)
+    implementation(libs.coil.network.okhttp)
 }

--- a/client/app/src/main/java/com/andone/memorip/MemoripApplication.kt
+++ b/client/app/src/main/java/com/andone/memorip/MemoripApplication.kt
@@ -4,17 +4,16 @@ import android.app.Application
 import android.util.Log
 import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
-import com.andone.memorip.domain.auth.TokenRefresher
-import com.andone.memorip.domain.repository.AuthRepository
+import coil3.ImageLoader
+import coil3.PlatformContext
+import coil3.SingletonImageLoader
+import coil3.network.okhttp.OkHttpNetworkFetcherFactory
+import coil3.request.crossfade
 import dagger.hilt.android.HiltAndroidApp
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltAndroidApp
-class MemoripApplication : Application(), Configuration.Provider {
+class MemoripApplication : Application(), Configuration.Provider, SingletonImageLoader.Factory {
     @Inject
     lateinit var workerFactory: HiltWorkerFactory
 
@@ -23,4 +22,16 @@ class MemoripApplication : Application(), Configuration.Provider {
             .setWorkerFactory(workerFactory)
             .setMinimumLoggingLevel(loggingLevel = Log.DEBUG)
             .build()
+
+    override fun newImageLoader(context: PlatformContext): ImageLoader {
+        return ImageLoader.Builder(context)
+            .components {
+                add(OkHttpNetworkFetcherFactory())
+            }
+            .crossfade(true)
+//            .apply {
+//                eventListenerFactory(ImageLoadingMetrics.Factory())
+//            }
+            .build()
+    }
 }

--- a/client/app/src/main/java/com/andone/memorip/MemoripApplication.kt
+++ b/client/app/src/main/java/com/andone/memorip/MemoripApplication.kt
@@ -29,9 +29,6 @@ class MemoripApplication : Application(), Configuration.Provider, SingletonImage
                 add(OkHttpNetworkFetcherFactory())
             }
             .crossfade(true)
-//            .apply {
-//                eventListenerFactory(ImageLoadingMetrics.Factory())
-//            }
             .build()
     }
 }

--- a/client/gradle/libs.versions.toml
+++ b/client/gradle/libs.versions.toml
@@ -1,7 +1,6 @@
 [versions]
 agp = "8.12.3"
-coilCompose = "2.6.0"
-coilNetworkOkhttp = "3.3.0"
+coil = "3.3.0"
 composeConvention = "1.2.2"
 credentialsPlayServicesAuth = "1.5.0"
 googleid = "1.2.0"
@@ -51,8 +50,8 @@ roomCompiler = "2.8.4"
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-credentials = { module = "androidx.credentials:credentials", version.ref = "credentialsPlayServicesAuth" }
 androidx-credentials-play-services-auth = { module = "androidx.credentials:credentials-play-services-auth", version.ref = "credentialsPlayServicesAuth" }
-coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coilCompose" }
-coil-network-okhttp = { module = "io.coil-kt.coil3:coil-network-okhttp", version.ref = "coilNetworkOkhttp" }
+coil-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref = "coil" }
+coil-network-okhttp = { group = "io.coil-kt.coil3", name = "coil-network-okhttp", version.ref = "coil" }
 firebase-auth = { module = "com.google.firebase:firebase-auth" }
 googleid = { module = "com.google.android.libraries.identity.googleid:googleid", version.ref = "googleid" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }

--- a/client/gradle/libs.versions.toml
+++ b/client/gradle/libs.versions.toml
@@ -50,6 +50,7 @@ roomCompiler = "2.8.4"
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-credentials = { module = "androidx.credentials:credentials", version.ref = "credentialsPlayServicesAuth" }
 androidx-credentials-play-services-auth = { module = "androidx.credentials:credentials-play-services-auth", version.ref = "credentialsPlayServicesAuth" }
+coil = { group = "io.coil-kt.coil3", name = "coil", version.ref = "coil" }
 coil-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref = "coil" }
 coil-network-okhttp = { group = "io.coil-kt.coil3", name = "coil-network-okhttp", version.ref = "coil" }
 firebase-auth = { module = "com.google.firebase:firebase-auth" }

--- a/client/presentation/build.gradle.kts
+++ b/client/presentation/build.gradle.kts
@@ -95,7 +95,6 @@ dependencies {
 
     // Coil
     implementation(libs.coil.compose)
-    implementation(libs.coil.network.okhttp)
 
     // Naver Map
     implementation(libs.naver.map.sdk)

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/component/MemoripImage.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/component/MemoripImage.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.painter.ColorPainter
 import androidx.compose.ui.layout.ContentScale
-import coil.compose.AsyncImage
+import coil3.compose.AsyncImage
 import com.andone.memorip.presentation.theme.MemoripTheme
 
 @Composable

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/component/MemoripImage.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/component/MemoripImage.kt
@@ -1,5 +1,6 @@
 package com.andone.memorip.presentation.component
 
+import android.graphics.Bitmap
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.painter.ColorPainter
@@ -9,6 +10,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import coil3.compose.AsyncImage
 import coil3.request.ImageRequest
+import coil3.request.bitmapConfig
 import coil3.request.crossfade
 import coil3.size.Precision
 import com.andone.memorip.presentation.theme.MemoripTheme
@@ -39,6 +41,7 @@ fun MemoripImage(
             }
             .precision(Precision.INEXACT)
             .crossfade(true)
+            .bitmapConfig(Bitmap.Config.RGB_565)
             .build(),
         contentDescription = contentDescription,
         modifier = modifier,

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/component/MemoripImage.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/component/MemoripImage.kt
@@ -4,18 +4,42 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.painter.ColorPainter
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
 import coil3.compose.AsyncImage
+import coil3.request.ImageRequest
+import coil3.request.crossfade
+import coil3.size.Precision
 import com.andone.memorip.presentation.theme.MemoripTheme
+import com.andone.memorip.presentation.util.toPx
 
 @Composable
 fun MemoripImage(
     imageUrl: String,
     contentDescription: String?,
     modifier: Modifier = Modifier,
-    contentScale: ContentScale = ContentScale.Crop
+    contentScale: ContentScale = ContentScale.Crop,
+    targetWidth: Dp? = null,
+    targetHeight: Dp? = null
 ) {
+    val context = LocalContext.current
+    val density = LocalDensity.current
+
+    val widthPx = targetWidth?.toPx(density)?.toInt()
+    val heightPx = targetHeight?.toPx(density)?.toInt()
+
     AsyncImage(
-        model = imageUrl,
+        model = ImageRequest.Builder(context)
+            .data(imageUrl)
+            .apply {
+                if (widthPx != null && heightPx != null) {
+                    size(widthPx, heightPx)
+                }
+            }
+            .precision(Precision.INEXACT)
+            .crossfade(true)
+            .build(),
         contentDescription = contentDescription,
         modifier = modifier,
         placeholder = ColorPainter(MemoripTheme.colors.primaryContainer),

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/component/map/BitmapMarkerLoader.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/component/map/BitmapMarkerLoader.kt
@@ -8,7 +8,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
-import coil3.ImageLoader
+import coil3.imageLoader
 import coil3.request.ImageRequest
 import coil3.request.SuccessResult
 import coil3.request.allowHardware
@@ -39,7 +39,7 @@ fun rememberBitmapMarkerLoader(
 
             launch(Dispatchers.IO) {
                 runCatching {
-                    val imageLoader = ImageLoader(context)
+                    val imageLoader = context.imageLoader
                     val request = ImageRequest.Builder(context)
                         .data(imageUrl)
                         .size(width, height)

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/component/map/BitmapMarkerLoader.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/component/map/BitmapMarkerLoader.kt
@@ -18,7 +18,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-private object MarkerImageConstants {
+private object MarkerImageConstant {
     const val WIDTH = 200
     const val HEIGHT = 200
     val BITMAP_CONFIG = Bitmap.Config.ARGB_8888
@@ -27,8 +27,8 @@ private object MarkerImageConstants {
 @Composable
 fun rememberBitmapMarkerLoader(
     imageUrls: List<String>,
-    width: Int = MarkerImageConstants.WIDTH,
-    height: Int = MarkerImageConstants.HEIGHT
+    width: Int = MarkerImageConstant.WIDTH,
+    height: Int = MarkerImageConstant.HEIGHT
 ): Map<String, Bitmap> {
     val context = LocalContext.current
     var markerImages by remember { mutableStateOf<Map<String, Bitmap>>(emptyMap()) }
@@ -52,7 +52,7 @@ fun rememberBitmapMarkerLoader(
                         result.image.toBitmap(
                             width = width,
                             height = height,
-                            config = MarkerImageConstants.BITMAP_CONFIG
+                            config = MarkerImageConstant.BITMAP_CONFIG
                         )
                     } else {
                         error("이미지 로드 실패")

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/component/map/BitmapMarkerLoader.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/component/map/BitmapMarkerLoader.kt
@@ -21,7 +21,7 @@ import kotlinx.coroutines.withContext
 private object MarkerImageConstant {
     const val WIDTH = 200
     const val HEIGHT = 200
-    val BITMAP_CONFIG = Bitmap.Config.ARGB_8888
+    val BITMAP_CONFIG = Bitmap.Config.RGB_565
 }
 
 @Composable

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/component/map/BitmapMarkerLoader.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/component/map/BitmapMarkerLoader.kt
@@ -3,15 +3,15 @@ package com.andone.memorip.presentation.component.map
 import android.graphics.Bitmap
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshots.SnapshotStateMap
 import androidx.compose.ui.platform.LocalContext
 import coil3.imageLoader
 import coil3.request.ImageRequest
 import coil3.request.SuccessResult
 import coil3.request.allowHardware
+import coil3.size.Precision
 import coil3.size.Scale
 import coil3.toBitmap
 import kotlinx.coroutines.Dispatchers
@@ -29,9 +29,9 @@ fun rememberBitmapMarkerLoader(
     imageUrls: List<String>,
     width: Int = MarkerImageConstant.WIDTH,
     height: Int = MarkerImageConstant.HEIGHT
-): Map<String, Bitmap> {
+): SnapshotStateMap<String, Bitmap> {
     val context = LocalContext.current
-    var markerImages by remember { mutableStateOf<Map<String, Bitmap>>(emptyMap()) }
+    val markerImages = remember { mutableStateMapOf<String, Bitmap>() }
 
     LaunchedEffect(imageUrls) {
         imageUrls.forEach { imageUrl ->
@@ -43,6 +43,7 @@ fun rememberBitmapMarkerLoader(
                     val request = ImageRequest.Builder(context)
                         .data(imageUrl)
                         .size(width, height)
+                        .precision(Precision.INEXACT)
                         .scale(Scale.FILL)
                         .allowHardware(false)
                         .build()
@@ -59,7 +60,7 @@ fun rememberBitmapMarkerLoader(
                     }
                 }.onSuccess { bitmap ->
                     withContext(Dispatchers.Main) {
-                        markerImages = markerImages + (imageUrl to bitmap)
+                        markerImages[imageUrl] = bitmap
                     }
                 }
             }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placecreate/component/SelectedImageItem.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placecreate/component/SelectedImageItem.kt
@@ -53,7 +53,9 @@ fun SelectedImageItem(
                     color = borderColor,
                     shape = MemoripTheme.shapes.roundedSmall
                 )
-                .clickable(onClick = onClick)
+                .clickable(onClick = onClick),
+            targetWidth = IMAGE_SIZE,
+            targetHeight = IMAGE_SIZE
         )
 
         Box(

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placedetail/PlaceDetailScreen.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placedetail/PlaceDetailScreen.kt
@@ -45,8 +45,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import coil3.compose.AsyncImage
 import com.andone.memorip.navigation.PlaceDetail
+import com.andone.memorip.presentation.component.MemoripImage
 import com.andone.memorip.presentation.R
 import com.andone.memorip.presentation.component.LoadingIndicatorScreen
 import com.andone.memorip.presentation.component.TagChipRow
@@ -225,6 +225,7 @@ private fun PlaceDetailContent(
     val statusBarHeightDp = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
     val maxHeaderHeight = LocalWindowInfo.current.containerDpSize.height - statusBarHeightDp
     val maxHeaderPx = maxHeaderHeight.toPx(density = density)
+    val screenWidth = LocalWindowInfo.current.containerDpSize.width
     val lazyListState = rememberLazyListState()
 
     CompositionLocalProvider(
@@ -277,11 +278,13 @@ private fun PlaceDetailContent(
                             state = pagerState,
                             key = { idx -> place.imageUrls[idx] }
                         ) { idx ->
-                            AsyncImage(
-                                modifier = Modifier.fillMaxSize(),
-                                model = place.imageUrls[idx],
+                            MemoripImage(
+                                imageUrl = place.imageUrls[idx],
                                 contentDescription = stringResource(R.string.place_detail_image_content_description),
+                                modifier = Modifier.fillMaxSize(),
                                 contentScale = ContentScale.Crop,
+                                targetWidth = screenWidth,
+                                targetHeight = maxHeaderHeight
                             )
                         }
 

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placedetail/PlaceDetailScreen.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placedetail/PlaceDetailScreen.kt
@@ -45,7 +45,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import coil.compose.AsyncImage
+import coil3.compose.AsyncImage
 import com.andone.memorip.navigation.PlaceDetail
 import com.andone.memorip.presentation.R
 import com.andone.memorip.presentation.component.LoadingIndicatorScreen

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placelist/component/StaggeredImageItem.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/placelist/component/StaggeredImageItem.kt
@@ -1,5 +1,6 @@
 package com.andone.memorip.presentation.screen.placelist.component
 
+import android.annotation.SuppressLint
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -17,6 +18,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -50,6 +52,7 @@ private object StaggeredImageItemConstant{
     val BOTTOM_RATIO = 1f
 }
 
+@SuppressLint("ConfigurationScreenWidthHeight")
 @Composable
 fun StaggeredImageItem(
     imageUrl: String,
@@ -60,6 +63,10 @@ fun StaggeredImageItem(
     contentDescription: String? = null,
     location: String? = null
 ) {
+    val configuration = LocalConfiguration.current
+    val screenWidth = configuration.screenWidthDp.dp
+    val imageHeight = screenWidth / aspectRatio
+
     Box(
         modifier = modifier
             .clickable(
@@ -76,7 +83,9 @@ fun StaggeredImageItem(
             contentDescription = contentDescription,
             modifier = Modifier
                 .fillMaxWidth()
-                .aspectRatio(aspectRatio)
+                .aspectRatio(aspectRatio),
+            targetWidth = screenWidth,
+            targetHeight = imageHeight
         )
 
         Box(

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/plan/component/PlacePickerItem.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/plan/component/PlacePickerItem.kt
@@ -15,8 +15,8 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import coil3.compose.AsyncImage
 import com.andone.memorip.presentation.R
+import com.andone.memorip.presentation.component.MemoripImage
 import com.andone.memorip.presentation.model.Place
 import com.andone.memorip.presentation.screen.plan.component.PlacePickerItemConstant.FULL_WEIGHT
 import com.andone.memorip.presentation.screen.plan.component.PlacePickerItemDimen.PLACE_PICKER_ITEM_HEIGHT
@@ -48,13 +48,15 @@ fun PlacePickerItem(
             )
             .clip(shape = MemoripTheme.shapes.roundedMedium)
     ) {
-        AsyncImage(
+        MemoripImage(
+            imageUrl = place.thumbnailImage.url,
+            contentDescription = stringResource(R.string.place_picker_item_image_description),
             modifier = Modifier
                 .weight(FULL_WEIGHT)
                 .fillMaxWidth(),
-            model = place.thumbnailImage.url,
-            contentDescription = stringResource(R.string.place_picker_item_image_description),
-            contentScale = ContentScale.Crop
+            contentScale = ContentScale.Crop,
+            targetWidth = PLACE_PICKER_ITEM_WIDTH,
+            targetHeight = PLACE_PICKER_ITEM_HEIGHT / 2
         )
         Column(
             modifier = Modifier

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/plan/component/PlacePickerItem.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/plan/component/PlacePickerItem.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import coil.compose.AsyncImage
+import coil3.compose.AsyncImage
 import com.andone.memorip.presentation.R
 import com.andone.memorip.presentation.model.Place
 import com.andone.memorip.presentation.screen.plan.component.PlacePickerItemConstant.FULL_WEIGHT

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/plan/component/PlaceTimeCard.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/plan/component/PlaceTimeCard.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -132,6 +133,8 @@ private fun CompactPlaceTimeCard(
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val imageSize = (place.durationMinutes * MINUTE_HEIGHT_DP).dp - MemoripPadding.PaddingMedium * 2
+
     Surface(
         onClick = onClick,
         modifier = modifier.fillMaxWidth(),
@@ -151,7 +154,9 @@ private fun CompactPlaceTimeCard(
                     .fillMaxHeight()
                     .aspectRatio(ratio = 1f)
                     .clip(shape = RoundedCornerShape(size = PlaceTimeCardDimen.IMAGE_CORNER_RADIUS)),
-                contentScale = ContentScale.Crop
+                contentScale = ContentScale.Crop,
+                targetWidth = imageSize,
+                targetHeight = imageSize
             )
 
             Column(verticalArrangement = Arrangement.spacedBy(space = MemoripSpace.SpaceXXSmall)) {
@@ -179,6 +184,11 @@ private fun ExpandedPlaceTimeCard(
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val configuration = LocalConfiguration.current
+    val screenWidth = configuration.screenWidthDp.dp
+    val cardHeight = (place.durationMinutes * MINUTE_HEIGHT_DP).dp
+    val imageHeight = cardHeight * 0.6f
+
     Surface(
         onClick = onClick,
         modifier = modifier.fillMaxWidth(),
@@ -194,7 +204,9 @@ private fun ExpandedPlaceTimeCard(
                     .fillMaxWidth()
                     .weight(weight = 1f)
                     .clip(shape = RoundedCornerShape(size = PlaceTimeCardDimen.IMAGE_CORNER_RADIUS)),
-                contentScale = ContentScale.Crop
+                contentScale = ContentScale.Crop,
+                targetWidth = screenWidth,
+                targetHeight = imageHeight
             )
 
             Column(

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/selectimage/component/ThumbnailItem.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/selectimage/component/ThumbnailItem.kt
@@ -16,8 +16,8 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
-import coil3.compose.AsyncImage
 import com.andone.memorip.presentation.R
+import com.andone.memorip.presentation.component.MemoripImage
 import com.andone.memorip.presentation.screen.selectimage.component.ThumbnailItemDimens.imageSize
 import com.andone.memorip.presentation.theme.MemoripAlpha
 import com.andone.memorip.presentation.theme.MemoripLineWidth
@@ -47,10 +47,12 @@ fun ThumbnailItem(
             )
             .clickable { onClick() }
     ) {
-        AsyncImage(
-            model = imageUri,
+        MemoripImage(
+            imageUrl = imageUri.toString(),
             contentDescription = null,
-            modifier = Modifier.fillMaxSize()
+            modifier = Modifier.fillMaxSize(),
+            targetWidth = imageSize,
+            targetHeight = imageSize
         )
 
         if (isDone) {

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/selectimage/component/ThumbnailItem.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/selectimage/component/ThumbnailItem.kt
@@ -16,7 +16,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
-import coil.compose.AsyncImage
+import coil3.compose.AsyncImage
 import com.andone.memorip.presentation.R
 import com.andone.memorip.presentation.screen.selectimage.component.ThumbnailItemDimens.imageSize
 import com.andone.memorip.presentation.theme.MemoripAlpha

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/selecttrip/component/TripImageGridMax3.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/selecttrip/component/TripImageGridMax3.kt
@@ -1,5 +1,6 @@
 package com.andone.memorip.presentation.screen.selecttrip.component
 
+import android.annotation.SuppressLint
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -15,8 +16,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.andone.memorip.presentation.R
 import com.andone.memorip.presentation.component.MemoripImage
 import com.andone.memorip.presentation.screen.selecttrip.component.TripImageGridMax3Constants.ASPECT_RATIO_HEIGHT
@@ -74,15 +77,22 @@ private fun EmptyImageState(
     }
 }
 
+@SuppressLint("ConfigurationScreenWidthHeight")
 @Composable
 private fun SingleImageLayout(
     imageUrl: String,
     modifier: Modifier = Modifier
 ) {
+    val configuration = LocalConfiguration.current
+    val screenWidth = configuration.screenWidthDp.dp
+    val containerHeight = screenWidth * ASPECT_RATIO_HEIGHT / ASPECT_RATIO_WIDTH
+
     MemoripImage(
         imageUrl = imageUrl,
         contentDescription = null,
-        modifier = modifier.fillMaxSize()
+        modifier = modifier.fillMaxSize(),
+        targetWidth = screenWidth,
+        targetHeight = containerHeight
     )
 }
 
@@ -92,6 +102,11 @@ private fun TwoImagesLayout(
     secondImage: String,
     modifier: Modifier = Modifier
 ) {
+    val configuration = LocalConfiguration.current
+    val screenWidth = configuration.screenWidthDp.dp
+    val containerHeight = screenWidth * ASPECT_RATIO_HEIGHT / ASPECT_RATIO_WIDTH
+    val imageWidth = screenWidth / 2
+
     Row(
         modifier = modifier.fillMaxSize(),
         horizontalArrangement = Arrangement.spacedBy(MemoripSpace.SpaceXXSmall)
@@ -101,14 +116,18 @@ private fun TwoImagesLayout(
             contentDescription = null,
             modifier = Modifier
                 .weight(1f)
-                .fillMaxHeight()
+                .fillMaxHeight(),
+            targetWidth = imageWidth,
+            targetHeight = containerHeight
         )
         MemoripImage(
             imageUrl = secondImage,
             contentDescription = null,
             modifier = Modifier
                 .weight(1f)
-                .fillMaxHeight()
+                .fillMaxHeight(),
+            targetWidth = imageWidth,
+            targetHeight = containerHeight
         )
     }
 }
@@ -120,6 +139,13 @@ private fun ThreeImagesLayout(
     thirdImage: String,
     modifier: Modifier = Modifier
 ) {
+    val configuration = LocalConfiguration.current
+    val screenWidth = configuration.screenWidthDp.dp
+    val containerHeight = screenWidth * ASPECT_RATIO_HEIGHT / ASPECT_RATIO_WIDTH
+    val largeImageWidth = screenWidth * THREE_IMAGES_LARGE_WEIGHT / (THREE_IMAGES_LARGE_WEIGHT + THREE_IMAGES_SMALL_WEIGHT)
+    val smallImageWidth = screenWidth * THREE_IMAGES_SMALL_WEIGHT / (THREE_IMAGES_LARGE_WEIGHT + THREE_IMAGES_SMALL_WEIGHT)
+    val smallImageHeight = containerHeight / 2
+
     Row(
         modifier = modifier.fillMaxSize(),
         horizontalArrangement = Arrangement.spacedBy(MemoripSpace.SpaceXXSmall)
@@ -129,7 +155,9 @@ private fun ThreeImagesLayout(
             contentDescription = null,
             modifier = Modifier
                 .weight(THREE_IMAGES_LARGE_WEIGHT)
-                .fillMaxHeight()
+                .fillMaxHeight(),
+            targetWidth = largeImageWidth,
+            targetHeight = containerHeight
         )
 
         Column(
@@ -143,14 +171,18 @@ private fun ThreeImagesLayout(
                 contentDescription = null,
                 modifier = Modifier
                     .weight(1f)
-                    .fillMaxWidth()
+                    .fillMaxWidth(),
+                targetWidth = smallImageWidth,
+                targetHeight = smallImageHeight
             )
             MemoripImage(
                 imageUrl = thirdImage,
                 contentDescription = null,
                 modifier = Modifier
                     .weight(1f)
-                    .fillMaxWidth()
+                    .fillMaxWidth(),
+                targetWidth = smallImageWidth,
+                targetHeight = smallImageHeight
             )
         }
     }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/TripDetailScreen.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/TripDetailScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.LoadState
+import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.andone.memorip.navigation.TripDetail
 import com.andone.memorip.presentation.component.map.MapClusterManager
@@ -74,6 +75,7 @@ fun TripDetailScreen(
     TripDetailScreenContent(
         tripName = uiState.tripName,
         places = places,
+        placesPagingItems = placesPagingItems,
         clusteredItems = clusteredItems,
         markerImages = markerImages,
         mapSelectedPlace = uiState.mapSelectedPlace,
@@ -92,6 +94,7 @@ fun TripDetailScreen(
 private fun TripDetailScreenContent(
     tripName: String,
     places: List<Place>,
+    placesPagingItems: LazyPagingItems<Place>,
     clusteredItems: List<MapClusterManager.ClusterItem>,
     markerImages: Map<String, android.graphics.Bitmap>,
     mapSelectedPlace: Place?,
@@ -119,6 +122,7 @@ private fun TripDetailScreenContent(
     ) { innerPadding ->
         TripMap(
             places = places,
+            placesPagingItems = placesPagingItems,
             clusteredItems = clusteredItems,
             markerImages = markerImages,
             mapBottomSheetContent = mapBottomSheetContent,
@@ -163,6 +167,7 @@ private fun TripDetailScreenContentPreview() {
         TripDetailScreenContent(
             tripName = "서울대공원 주암 나들이",
             places = DummyData.places,
+            placesPagingItems = DummyData.getPlacePagingItems(),
             clusteredItems = clusteredItems,
             markerImages = emptyMap(),
             mapSelectedPlace = null,

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/component/BottomSheetPlaceDetailContent.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/component/BottomSheetPlaceDetailContent.kt
@@ -26,7 +26,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import coil.compose.AsyncImagePainter.State.Empty.painter
 import com.andone.memorip.presentation.R
 import com.andone.memorip.presentation.component.MemoripImage
 import com.andone.memorip.presentation.component.PlaceLocationText

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/component/BottomSheetPlaceDetailContent.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/component/BottomSheetPlaceDetailContent.kt
@@ -97,7 +97,9 @@ fun BottomSheetPlaceDetailContent(
                         .size(BottomSheetPlaceDetailContentDimen.IMAGE_SIZE)
                         .aspectRatio(1f)
                         .clip(RoundedCornerShape(BottomSheetPlaceDetailContentDimen.IMAGE_CORNER_RADIUS)),
-                    contentScale = ContentScale.Crop
+                    contentScale = ContentScale.Crop,
+                    targetWidth = BottomSheetPlaceDetailContentDimen.IMAGE_SIZE,
+                    targetHeight = BottomSheetPlaceDetailContentDimen.IMAGE_SIZE
                 )
                 Column(
                     modifier = Modifier

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/component/BottomSheetPlaceGridContent.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/component/BottomSheetPlaceGridContent.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
-import androidx.compose.foundation.lazy.staggeredgrid.items
 import androidx.compose.foundation.lazy.staggeredgrid.rememberLazyStaggeredGridState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -17,6 +16,7 @@ import com.andone.memorip.presentation.screen.tripdetail.model.TripDetailAction
 import com.andone.memorip.presentation.theme.MemoripPadding
 import com.andone.memorip.presentation.theme.MemoripSpace
 import androidx.compose.ui.unit.dp
+import androidx.paging.compose.LazyPagingItems
 import com.andone.memorip.presentation.theme.MemoripTheme
 import com.andone.memorip.presentation.util.DummyData
 
@@ -26,7 +26,7 @@ private object BottomSheetPlaceGridDimens {
 
 @Composable
 fun BottomSheetPlaceGridContent(
-    places: List<Place>,
+    placesPagingItems: LazyPagingItems<Place>,
     onAction: (TripDetailAction) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -46,17 +46,19 @@ fun BottomSheetPlaceGridContent(
         )
     ) {
         items(
-            items = places,
-            key = { it.placeId }
-        ) { place ->
-            val image = place.thumbnailImage
-            StaggeredImageItem(
-                imageUrl = image.url,
-                aspectRatio = image.aspectRatio,
-                onImageClick = { onAction(TripDetailAction.OnPlaceClick(place)) },
-                contentDescription = place.name,
-                location = place.address,
-            )
+            count = placesPagingItems.itemCount,
+            key = { index -> placesPagingItems.peek(index)?.placeId ?: index }
+        ) { index ->
+            placesPagingItems[index]?.let { place ->
+                val image = place.thumbnailImage
+                StaggeredImageItem(
+                    imageUrl = image.url,
+                    aspectRatio = image.aspectRatio,
+                    onImageClick = { onAction(TripDetailAction.OnPlaceClick(place)) },
+                    contentDescription = place.name,
+                    location = place.address,
+                )
+            }
         }
     }
 }
@@ -66,7 +68,7 @@ fun BottomSheetPlaceGridContent(
 private fun BottomSheetPlaceGridContentPreview() {
     MemoripTheme {
         BottomSheetPlaceGridContent(
-            places = DummyData.places,
+            placesPagingItems = DummyData.getPlacePagingItems(),
             onAction = {}
         )
     }

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/component/BottomSheetPlaceListContent.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/component/BottomSheetPlaceListContent.kt
@@ -4,11 +4,11 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.paging.compose.LazyPagingItems
 import com.andone.memorip.presentation.model.Place
 import com.andone.memorip.presentation.screen.tripdetail.model.TripDetailAction
 import com.andone.memorip.presentation.theme.MemoripPadding
@@ -17,7 +17,7 @@ import com.andone.memorip.presentation.util.DummyData
 
 @Composable
 fun BottomSheetPlaceListContent(
-    places: List<Place>,
+    placesPagingItems: LazyPagingItems<Place>,
     listState: LazyListState,
     onAction: (TripDetailAction) -> Unit,
     modifier: Modifier = Modifier,
@@ -31,15 +31,17 @@ fun BottomSheetPlaceListContent(
         )
     ) {
         items(
-            items = places,
-            key = { it.placeId }
-        ) { place ->
-            BottomSheetPlaceListItem(
-                place = place,
-                onClick = {
-                    onAction(TripDetailAction.OnPlaceClick(place))
-                }
-            )
+            count = placesPagingItems.itemCount,
+            key = { index -> placesPagingItems.peek(index)?.placeId ?: index }
+        ) { index ->
+            placesPagingItems[index]?.let { place ->
+                BottomSheetPlaceListItem(
+                    place = place,
+                    onClick = {
+                        onAction(TripDetailAction.OnPlaceClick(place))
+                    }
+                )
+            }
         }
     }
 }
@@ -50,7 +52,7 @@ private fun BottomSheetPlaceListContentPreview() {
     MemoripTheme {
         val listState = rememberLazyListState()
         BottomSheetPlaceListContent(
-            places = DummyData.places,
+            placesPagingItems = DummyData.getPlacePagingItems(),
             listState = listState,
             onAction = {}
         )

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/component/BottomSheetPlaceListItem.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/component/BottomSheetPlaceListItem.kt
@@ -62,7 +62,9 @@ fun BottomSheetPlaceListItem(
                     modifier = Modifier
                         .size(size = BottomSheetPlaceListItemDimen.IMAGE_SIZE)
                         .clip(shape = RoundedCornerShape(size = BottomSheetPlaceListItemDimen.IMAGE_CORNER_RADIUS)),
-                    contentScale = ContentScale.Crop
+                    contentScale = ContentScale.Crop,
+                    targetWidth = BottomSheetPlaceListItemDimen.IMAGE_SIZE,
+                    targetHeight = BottomSheetPlaceListItemDimen.IMAGE_SIZE
                 )
 
                 Column(verticalArrangement = Arrangement.spacedBy(space = MemoripSpace.SpaceXXSmall)) {

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/component/TripMap.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/component/TripMap.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.paging.compose.LazyPagingItems
 import com.andone.memorip.presentation.theme.MemoripTheme
 import com.andone.memorip.presentation.util.DummyData
 
@@ -48,6 +49,7 @@ private object TripMapConstant {
 @Composable
 fun TripMap(
     places: List<Place>,
+    placesPagingItems: LazyPagingItems<Place>,
     clusteredItems: List<MapClusterManager.ClusterItem>,
     markerImages: Map<String, Bitmap>,
     mapBottomSheetContent: MapBottomSheetStep,
@@ -186,6 +188,7 @@ fun TripMap(
 
     TripMapContent(
         places = places,
+        placesPagingItems = placesPagingItems,
         clusteredItems = clusteredItems,
         markerImages = markerImages,
         cameraPositionState = cameraPositionState,
@@ -243,6 +246,7 @@ private fun TripMapPreview() {
 
         TripMap(
             places = DummyData.places,
+            placesPagingItems = DummyData.getPlacePagingItems(),
             clusteredItems = clusteredItems,
             markerImages = emptyMap(),
             mapBottomSheetContent = MapBottomSheetStep.PlaceList,

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/component/TripMapContent.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/tripdetail/component/TripMapContent.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.andone.memorip.presentation.util.DummyData
 import com.naver.maps.map.compose.rememberCameraPositionState
 import androidx.compose.material3.rememberBottomSheetScaffoldState
+import androidx.paging.compose.LazyPagingItems
 
 private object TripMapContentDimen {
     val SHEET_PEEK_HEIGHT = 200.dp
@@ -51,6 +52,7 @@ private object TripMapContentDimen {
 @Composable
 fun TripMapContent(
     places: List<Place>,
+    placesPagingItems: LazyPagingItems<Place>,
     clusteredItems: List<MapClusterManager.ClusterItem>,
     markerImages: Map<String, Bitmap>,
     cameraPositionState: CameraPositionState,
@@ -80,6 +82,7 @@ fun TripMapContent(
                 MapBottomSheetContent(
                     bottomSheetContent = mapBottomSheetContent,
                     places = places,
+                    placesPagingItems = placesPagingItems,
                     selectedPlace = mapSelectedPlace,
                     viewMode = viewMode,
                     hasMorePages = hasMorePages,
@@ -134,6 +137,7 @@ fun TripMapContent(
 private fun MapBottomSheetContent(
     bottomSheetContent: MapBottomSheetStep,
     places: List<Place>,
+    placesPagingItems: LazyPagingItems<Place>,
     selectedPlace: Place?,
     viewMode: PlaceViewMode,
     onAction: (TripDetailAction) -> Unit,
@@ -180,7 +184,7 @@ private fun MapBottomSheetContent(
                             when (viewMode) {
                                 PlaceViewMode.LIST -> {
                                     BottomSheetPlaceListContent(
-                                        places = places,
+                                        placesPagingItems = placesPagingItems,
                                         listState = placeListState,
                                         onAction = onAction
                                     )
@@ -188,7 +192,7 @@ private fun MapBottomSheetContent(
 
                                 PlaceViewMode.GRID -> {
                                     BottomSheetPlaceGridContent(
-                                        places = places,
+                                        placesPagingItems = placesPagingItems,
                                         onAction = onAction
                                     )
                                 }
@@ -239,6 +243,7 @@ private fun TripMapContentPreview() {
 
         TripMapContent(
             places = DummyData.places,
+            placesPagingItems = DummyData.getPlacePagingItems(),
             clusteredItems = clusteredItems,
             markerImages = emptyMap(),
             cameraPositionState = rememberCameraPositionState(),

--- a/client/presentation/src/main/java/com/andone/memorip/presentation/screen/user/component/UserProfileSection.kt
+++ b/client/presentation/src/main/java/com/andone/memorip/presentation/screen/user/component/UserProfileSection.kt
@@ -86,7 +86,9 @@ fun UserProfileSection(
                         modifier = Modifier
                             .fillMaxSize()
                             .clip(CircleShape),
-                        contentScale = ContentScale.Crop
+                        contentScale = ContentScale.Crop,
+                        targetWidth = PROFILE_IMAGE_SIZE,
+                        targetHeight = PROFILE_IMAGE_SIZE
                     )
                 }
             }


### PR DESCRIPTION
## 📝 변경 사항
맵 마커에 표시되는 이미지 로딩 성능을 개선하기 위해 Coil 라이브러리를 최신 버전(v3)으로 업데이트하고 싱글턴 이미지 로더를 적용했습니다.

## 🎯 작업 내용
* Coil 라이브러리를 v2에서 v3(`3.3.0`)으로 업그레이드
* Coil의 `SingletonImageLoader`를 사용하여 앱 전역에서 이미지 로더 인스턴스를 공유하도록 설정
* `MemoripApplication`에 `SingletonImageLoader.Factory` 구현
* `OkHttpNetworkFetcherFactory` 추가 및 크로스페이드 효과 기본 적용
* `BitmapMarkerLoader`에서 `Context.imageLoader` 확장 함수를 사용하도록 수정
* Coil 관련 의존성 구성 개선 (`coil-network-okhttp` 등)
* 여행 상세 화면 내 장소 목록 페이징 처리 버그 수정

## 🔗 관련 이슈
Closes #211

## 📸 스크린샷 (선택사항)
<!-- UI 변경사항이 있다면 스크린샷을 추가해주세요 -->

## 💬 리뷰어에게
Coil v3로 업그레이드하면서 API가 일부 변경되었습니다.